### PR TITLE
Fix missing prototypes

### DIFF
--- a/flint-extras/src/fmpz_extra.h
+++ b/flint-extras/src/fmpz_extra.h
@@ -157,8 +157,13 @@ void fmpz_multimod_CRT_CRT(fmpz_t A, nn_srcptr m, const fmpz_multimod_CRT_t mmod
 /* by cofactors at the leaves                                        */
 /* result is still reduced modulo the product of moduli              */
 /*-------------------------------------------------------------------*/
-void fmpz_multi_CRT_combine(fmpz_t output, const fmpz_multi_CRT_t P, fmpz * inputs);
+void _fmpz_multi_CRT_combine(fmpz * outputs,
+                             const fmpz_multi_CRT_t P,
+                             fmpz * inputs);
 
+void fmpz_multi_CRT_combine(fmpz_t output,
+                            const fmpz_multi_CRT_t P,
+                            fmpz * inputs);
 
 
 #ifdef __cplusplus

--- a/flint-extras/src/fmpz_extra/fmpz_multi_CRT_combine.c
+++ b/flint-extras/src/fmpz_extra/fmpz_multi_CRT_combine.c
@@ -10,7 +10,7 @@
     <https://www.gnu.org/licenses/>.
 */
 
-#include <flint/fmpz.h>
+#include "fmpz_extra.h"
 
 /*-------------------------------------------------------------------*/
 /* similar to fmpz_multi_CRT_precomp, except that we do not multiply */

--- a/flint-extras/src/nmod_mat_extra/nmod_mat_mul_2dot.c
+++ b/flint-extras/src/nmod_mat_extra/nmod_mat_mul_2dot.c
@@ -10,10 +10,10 @@
     <https://www.gnu.org/licenses/>.
 */
 
-#include <flint/nmod_mat.h>
-#include <flint/nmod_vec.h>
+#include <flint/nmod_vec.h>  /* for DOT_SPLIT_BITS */
 
 #include "nmod_vec_extra.h"
+#include "nmod_mat_extra.h"
 
 #if FLINT_BITS == 64
 /** matrix multiplication using AVX2 instructions for moduli less than 2^30 */

--- a/flint-extras/src/nmod_mat_extra/nmod_mat_mul_newdot.c
+++ b/flint-extras/src/nmod_mat_extra/nmod_mat_mul_newdot.c
@@ -10,12 +10,11 @@
     <https://www.gnu.org/licenses/>.
 */
 
-#include <flint/longlong.h> // for BIT_COUNT
 #include <flint/flint.h>
-#include <flint/nmod_mat.h>
+#include <flint/longlong.h> // for BIT_COUNT
 #include <flint/nmod_vec.h>  // for _nmod_vec_init
 
-#include "nmod_vec_extra.h"
+#include "nmod_mat_extra.h"
 
 void nmod_mat_mul_newdot(nmod_mat_t C, const nmod_mat_t A, const nmod_mat_t B)
 {

--- a/flint-extras/src/nmod_poly_mat_extra/impl.h
+++ b/flint-extras/src/nmod_poly_mat_extra/impl.h
@@ -1,0 +1,40 @@
+/*
+    Copyright (C) 2026 Vincent Neiger
+
+    This file is part of PML.
+
+    PML is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License version 2.0 (GPL-2.0-or-later)
+    as published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version. See
+    <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef NMOD_POLY_MAT_EXTRA_IMPL_H
+#define NMOD_POLY_MAT_EXTRA_IMPL_H
+
+#include <flint/nmod_poly_mat.h>
+
+/* Hermite form helpers */
+void _atomic_solve_pivot_collision_uechelon_rowwise(nmod_poly_mat_t mat, nmod_poly_mat_t other,
+                                                    slong pi1, slong pi2, slong j);
+void _pivot_collision_xgcd_uref(nmod_poly_mat_t mat, nmod_poly_mat_t other,
+                                                      slong pi, slong ii, slong j,
+                                                      nmod_poly_t g, nmod_poly_t u, nmod_poly_t v,
+                                                      nmod_poly_t pivg, nmod_poly_t nonzg);
+void _reduce_against_pivot_uref(nmod_poly_mat_t mat, nmod_poly_mat_t other,
+                                            slong i, slong j, slong ii,
+                                            nmod_poly_t u, nmod_poly_t v);
+ulong _normalize_pivot_uref(nmod_poly_mat_t mat, nmod_poly_mat_t other, slong i, slong j);
+void _normalize_uref(nmod_poly_mat_t mat, nmod_poly_mat_t other, slong * pivind, slong rk);
+
+/* weak Popov form helpers */
+void _atomic_solve_pivot_collision_rowwise(nmod_poly_mat_t mat, nmod_poly_mat_t other,
+                                           slong pi1, slong pi2, slong j);
+void _reduce_against_pivot_general_rowwise(nmod_poly_mat_t mat, nmod_poly_mat_t other,
+                                   slong i, slong j, slong ii,
+                                   nmod_poly_t u, nmod_poly_t v);
+ulong _normalize_pivot_general_rowwise(nmod_poly_mat_t mat, nmod_poly_mat_t other, slong i, slong j);
+
+#endif  /* NMOD_POLY_MAT_EXTRA_IMPL_H */
+

--- a/flint-extras/src/nmod_poly_mat_extra/mul_waksman.c
+++ b/flint-extras/src/nmod_poly_mat_extra/mul_waksman.c
@@ -12,6 +12,7 @@
 
 #include <flint/nmod_poly.h>
 #include <flint/nmod_poly_mat.h>
+#include "nmod_poly_mat_multiply.h"
 
 void nmod_poly_mat_mul_waksman(nmod_poly_mat_t C, const nmod_poly_mat_t A,  const nmod_poly_mat_t B)
 {

--- a/flint-extras/src/nmod_poly_mat_extra/nmod_poly_mat_det.c
+++ b/flint-extras/src/nmod_poly_mat_extra/nmod_poly_mat_det.c
@@ -11,8 +11,9 @@
 */
 
 #include <flint/nmod_vec.h>
-#include "nmod_poly_mat_utils.h" // for permute_rows_by_sorting_vec
+#include "nmod_poly_mat_utils.h"  /* for permute_rows_by_sorting_vec */
 #include "nmod_poly_mat_forms.h"
+#include "nmod_poly_mat_extra.h"  /* for prototype of det_iter */
 
 // Mulders-Storjohann determinant algorithm
 // matrix must be square, not tested

--- a/flint-extras/src/nmod_poly_mat_extra/nmod_poly_mat_hermite.c
+++ b/flint-extras/src/nmod_poly_mat_extra/nmod_poly_mat_hermite.c
@@ -15,6 +15,7 @@
 #include <flint/nmod.h>
 #include "nmod_poly_mat_utils.h"
 #include "nmod_poly_mat_forms.h"
+#include "nmod_poly_mat_extra/impl.h"
 
 #if __FLINT_VERSION < 3 || (__FLINT_VERSION == 3 && __FLINT_VERSION_MINOR < 3)
 #  define MAT(i,j) (mat->rows[i] + j)

--- a/flint-extras/src/nmod_poly_mat_extra/nmod_poly_mat_weak_popov.c
+++ b/flint-extras/src/nmod_poly_mat_extra/nmod_poly_mat_weak_popov.c
@@ -16,6 +16,7 @@
 
 #include "nmod_poly_mat_utils.h"
 #include "nmod_poly_mat_forms.h"
+#include "nmod_poly_mat_extra/impl.h"
 
 #if __FLINT_VERSION < 3 || (__FLINT_VERSION == 3 && __FLINT_VERSION_MINOR < 3)
 #  define MAT(i,j) (mat->rows[i] + j)

--- a/flint-extras/src/nmod_poly_mat_extra/verification.c
+++ b/flint-extras/src/nmod_poly_mat_extra/verification.c
@@ -10,10 +10,11 @@
     <https://www.gnu.org/licenses/>.
 */
 
-#include "nmod_poly_mat_forms.h"
 #include <flint/nmod_mat.h>
 #include <flint/nmod_poly.h>
 #include <flint/nmod_poly_mat.h>
+#include "nmod_poly_mat_forms.h"
+#include "nmod_poly_mat_extra.h"  /* for prototypes */
 
 /* TODO currently specialized to ROW_LOWER (or at least ROW_stuff) */
 int nmod_poly_mat_is_approximant_basis(const nmod_poly_mat_t appbas,


### PR DESCRIPTION
Add missing prototypes in fmpz_extra and nmod_poly_mat_extra (except concerning the kernel basis functions).