### PR TITLE
pmbasis linearized 

### DIFF
--- a/flint-extras/src/mapml/mapml_matpoly_export.c
+++ b/flint-extras/src/mapml/mapml_matpoly_export.c
@@ -19,6 +19,7 @@
 
 #include <string.h>
 #include "mapml_conversion.h"
+#include "mapml_matpoly_export.h"
 
 /***********************************************************
  * 

--- a/flint-extras/src/nmod_poly_mat_approximant.h
+++ b/flint-extras/src/nmod_poly_mat_approximant.h
@@ -316,6 +316,13 @@ void nmod_poly_mat_mbasis(nmod_poly_mat_t appbas,
 
 // TODO doc
 // TODO middle_product currently naive
+
+
+void nmod_poly_mat_pmbasis_old(nmod_poly_mat_t appbas,
+                           slong * shift,
+                           const nmod_poly_mat_t pmat,
+                           slong order);
+
 void nmod_poly_mat_pmbasis(nmod_poly_mat_t appbas,
                            slong * shift,
                            const nmod_poly_mat_t pmat,

--- a/flint-extras/src/nmod_poly_mat_approximant.h
+++ b/flint-extras/src/nmod_poly_mat_approximant.h
@@ -330,6 +330,15 @@ void nmod_poly_mat_pmbasis(nmod_poly_mat_t appbas,
 
 /** nmod_poly_mat_pmbasis strategy using geometric multiplications instead 
  *   and linearization for the residual computation 
+ * 
+ *  todo: check using 'if (order <= (ipmat->r))' instead 
+ *           improves things for large example 
+ * 
+ *  todo: tune the test for switching to mbasis 
+ * 
+ *  todo ASSUMPTION (not checked): existence of element of "large enough" order
+ *           and fail flag when element not found 
+ * 
  */
 
 void nmod_poly_mat_pmbasis_linearized(nmod_poly_mat_t appbas,

--- a/flint-extras/src/nmod_poly_mat_approximant.h
+++ b/flint-extras/src/nmod_poly_mat_approximant.h
@@ -328,6 +328,15 @@ void nmod_poly_mat_pmbasis(nmod_poly_mat_t appbas,
                            const nmod_poly_mat_t pmat,
                            slong order);
 
+/** nmod_poly_mat_pmbasis srategy using geometric multiplications instead 
+ *   and linearization for the residual computation 
+ */
+
+void nmod_poly_mat_pmbasis_linearized(nmod_poly_mat_t appbas,
+                           slong * shift,
+                           const nmod_poly_mat_t pmat,
+                           slong order);
+
 
 /** Computes a `shift`-Popov approximant basis for `(pmat,order)` using the
  * algorithm PM-Basis (see @ref pmbasis) twice: the first call yields an

--- a/flint-extras/src/nmod_poly_mat_approximant.h
+++ b/flint-extras/src/nmod_poly_mat_approximant.h
@@ -316,27 +316,10 @@ void nmod_poly_mat_mbasis(nmod_poly_mat_t appbas,
 
 // TODO doc
 // TODO middle_product currently naive
-
-
-void nmod_poly_mat_pmbasis_old(nmod_poly_mat_t appbas,
-                           slong * shift,
-                           const nmod_poly_mat_t pmat,
-                           slong order);
-
 void nmod_poly_mat_pmbasis(nmod_poly_mat_t appbas,
                            slong * shift,
                            const nmod_poly_mat_t pmat,
                            slong order);
-
-/** Using geometric matrix product for the partial bases
- *   and linearises the product residual x basis 
- */
-
-void nmod_poly_mat_pmbasis_geometric(nmod_poly_mat_t appbas,
-                           slong * shift,
-                           const nmod_poly_mat_t pmat,
-                           slong order);
-
 
 
 /** Computes a `shift`-Popov approximant basis for `(pmat,order)` using the

--- a/flint-extras/src/nmod_poly_mat_approximant.h
+++ b/flint-extras/src/nmod_poly_mat_approximant.h
@@ -328,7 +328,7 @@ void nmod_poly_mat_pmbasis(nmod_poly_mat_t appbas,
                            const nmod_poly_mat_t pmat,
                            slong order);
 
-/** nmod_poly_mat_pmbasis srategy using geometric multiplications instead 
+/** nmod_poly_mat_pmbasis strategy using geometric multiplications instead 
  *   and linearization for the residual computation 
  */
 

--- a/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
+++ b/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
@@ -116,7 +116,8 @@ void nmod_poly_mat_pmbasis_linearized(nmod_poly_mat_t appbas,
     nmod_poly_mat_init(pmat, ipmat->r, ipmat->c, ipmat->modulus);
     nmod_poly_mat_set_trunc(pmat,ipmat,order);
 
-    if (order <= PMBASIS_THRES)
+    //if (order <= PMBASIS_THRES)
+    if (order <= (ipmat->r))    
     {
         nmod_poly_mat_mbasis(appbas, shift, pmat, order);
         return;

--- a/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
+++ b/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
@@ -138,7 +138,7 @@ void nmod_poly_mat_pmbasis_linearized(nmod_poly_mat_t appbas,
 
     nmod_poly_mat_pmbasis_linearized(appbas, shift, pmat, order1);
 
-    nmod_poly_mat_middle_product_linearized(residual, appbas, pmat, order1, order2-1);
+    nmod_poly_mat_mulmid_linearized(residual, appbas, pmat, order1, order);
 
     nmod_poly_mat_pmbasis_linearized(appbas2, shift, residual, order2);
 

--- a/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
+++ b/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
@@ -48,11 +48,11 @@ void nmod_poly_mat_pmbasis_old(nmod_poly_mat_t appbas,
     nmod_poly_mat_init(appbas2, pmat->r, pmat->r, pmat->modulus);
     nmod_poly_mat_init(residual, pmat->r, pmat->c, pmat->modulus);
 
-    nmod_poly_mat_pmbasis(appbas, shift, pmat, order1);
+    nmod_poly_mat_pmbasis_old(appbas, shift, pmat, order1);
 
-    nmod_poly_mat_middle_product_naive(residual, appbas, pmat, order1, order2-1);
+    nmod_poly_mat_middle_product_naive_old(residual, appbas, pmat, order1, order2-1);
 
-    nmod_poly_mat_pmbasis(appbas2, shift, residual, order2);
+    nmod_poly_mat_pmbasis_old(appbas2, shift, residual, order2);
 
     nmod_poly_mat_mul(appbas, appbas2, appbas);
 

--- a/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
+++ b/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
@@ -30,47 +30,11 @@ void nmod_poly_mat_mbasis(nmod_poly_mat_t appbas,
     nmod_mat_poly_clear(app);
 }
 
-void nmod_poly_mat_pmbasis_old(nmod_poly_mat_t appbas,
+void nmod_poly_mat_pmbasis(nmod_poly_mat_t appbas,
                            slong * shift,
                            const nmod_poly_mat_t pmat,
                            slong order)
 {
-    if (order <= PMBASIS_THRES)
-    {
-        nmod_poly_mat_mbasis(appbas, shift, pmat, order);
-        return;
-    }
-
-    const long order1 = order>>1;
-    const long order2 = order - order1;
-    nmod_poly_mat_t appbas2, residual;
-
-    nmod_poly_mat_init(appbas2, pmat->r, pmat->r, pmat->modulus);
-    nmod_poly_mat_init(residual, pmat->r, pmat->c, pmat->modulus);
-
-    nmod_poly_mat_pmbasis_old(appbas, shift, pmat, order1);
-
-    nmod_poly_mat_middle_product_naive_old(residual, appbas, pmat, order1, order2-1);
-
-    nmod_poly_mat_pmbasis_old(appbas2, shift, residual, order2);
-
-    nmod_poly_mat_mul(appbas, appbas2, appbas);
-
-    nmod_poly_mat_clear(appbas2);
-    nmod_poly_mat_clear(residual);
-}
-
-void nmod_poly_mat_pmbasis(nmod_poly_mat_t appbas,
-                           slong * shift,
-                           const nmod_poly_mat_t ipmat,
-                           slong order)
-{
-
-    nmod_poly_mat_t pmat;
-
-    nmod_poly_mat_init(pmat, ipmat->r, ipmat->c, ipmat->modulus);
-    nmod_poly_mat_set_trunc(pmat,ipmat,order);
-
     if (order <= PMBASIS_THRES)
     {
         nmod_poly_mat_mbasis(appbas, shift, pmat, order);
@@ -95,41 +59,3 @@ void nmod_poly_mat_pmbasis(nmod_poly_mat_t appbas,
     nmod_poly_mat_clear(appbas2);
     nmod_poly_mat_clear(residual);
 }
-
-void nmod_poly_mat_pmbasis_geometric(nmod_poly_mat_t appbas,
-                           slong * shift,
-                           const nmod_poly_mat_t ipmat,
-                           slong order)
-{
-
-    nmod_poly_mat_t pmat;
-
-    nmod_poly_mat_init(pmat, ipmat->r, ipmat->c, ipmat->modulus);
-    nmod_poly_mat_set_trunc(pmat,ipmat,order);
-
-    if (order <= PMBASIS_THRES)
-    {
-        nmod_poly_mat_mbasis(appbas, shift, pmat, order);
-        return;
-    }
-
-    const long order1 = order>>1;
-    const long order2 = order - order1;
-    nmod_poly_mat_t appbas2, residual;
-
-    nmod_poly_mat_init(appbas2, pmat->r, pmat->r, pmat->modulus);
-    nmod_poly_mat_init(residual, pmat->r, pmat->c, pmat->modulus);
-
-    nmod_poly_mat_pmbasis_geometric(appbas, shift, pmat, order1);
-
-    nmod_poly_mat_middle_product_naive(residual, appbas, pmat, order1, order2-1);
-
-    nmod_poly_mat_pmbasis_geometric(appbas2, shift, residual, order2);
-
-    nmod_poly_mat_mul_geometric(appbas, appbas2, appbas);
-
-    nmod_poly_mat_clear(appbas2);
-    nmod_poly_mat_clear(residual);
-}
-
-

--- a/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
+++ b/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
@@ -103,6 +103,8 @@ void nmod_poly_mat_pmbasis(nmod_poly_mat_t appbas,
  *  todo: check using 'if (order <= (ipmat->r))' instead 
  *           improves things for large example 
  * 
+ *  todo: tune the test for switching to mbasis 
+ * 
  */
 
 void nmod_poly_mat_pmbasis_linearized(nmod_poly_mat_t appbas,
@@ -110,13 +112,11 @@ void nmod_poly_mat_pmbasis_linearized(nmod_poly_mat_t appbas,
                            const nmod_poly_mat_t ipmat,
                            slong order)
 {
-
     nmod_poly_mat_t pmat;
 
     nmod_poly_mat_init(pmat, ipmat->r, ipmat->c, ipmat->modulus);
     nmod_poly_mat_set_trunc(pmat,ipmat,order);
 
-    //if (order <= PMBASIS_THRES)
     if (order <= (ipmat->r))    
     {
         nmod_poly_mat_mbasis(appbas, shift, pmat, order);

--- a/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
+++ b/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
@@ -97,13 +97,16 @@ void nmod_poly_mat_pmbasis(nmod_poly_mat_t appbas,
 }
 
 
-/** nmod_poly_mat_pmbasis srategy using geometric multiplications instead 
+/** nmod_poly_mat_pmbasis strategy using geometric multiplications instead 
  *   and linearization for the residual computation 
  * 
  *  todo: check using 'if (order <= (ipmat->r))' instead 
  *           improves things for large example 
  * 
  *  todo: tune the test for switching to mbasis 
+ * 
+ *  todo ASSUMPTION (not checked): existence of element of "large enough" order
+ *           and fail flag when element not found 
  * 
  */
 

--- a/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
+++ b/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
@@ -97,3 +97,7 @@ void nmod_poly_mat_pmbasis(nmod_poly_mat_t appbas,
 }
 
 
+
+
+
+

--- a/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
+++ b/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
@@ -97,6 +97,53 @@ void nmod_poly_mat_pmbasis(nmod_poly_mat_t appbas,
 }
 
 
+/** nmod_poly_mat_pmbasis srategy using geometric multiplications instead 
+ *   and linearization for the residual computation 
+ * 
+ *  todo: check using 'if (order <= (ipmat->r))' instead 
+ *           improves things for large example 
+ * 
+ */
+
+void nmod_poly_mat_pmbasis_linearized(nmod_poly_mat_t appbas,
+                           slong * shift,
+                           const nmod_poly_mat_t ipmat,
+                           slong order)
+{
+
+    nmod_poly_mat_t pmat;
+
+    nmod_poly_mat_init(pmat, ipmat->r, ipmat->c, ipmat->modulus);
+    nmod_poly_mat_set_trunc(pmat,ipmat,order);
+
+    if (order <= PMBASIS_THRES)
+    {
+        nmod_poly_mat_mbasis(appbas, shift, pmat, order);
+        return;
+    }
+
+    const long order1 = order>>1;
+    const long order2 = order - order1;
+    nmod_poly_mat_t appbas2, residual;
+
+    nmod_poly_mat_init(appbas2, pmat->r, pmat->r, pmat->modulus);
+    nmod_poly_mat_init(residual, pmat->r, pmat->c, pmat->modulus);
+
+    nmod_poly_mat_pmbasis_linearized(appbas, shift, pmat, order1);
+
+    nmod_poly_mat_middle_product_linearized(residual, appbas, pmat, order1, order2-1);
+
+    nmod_poly_mat_pmbasis_linearized(appbas2, shift, residual, order2);
+
+    nmod_poly_mat_mul_geometric(appbas, appbas2, appbas);
+
+    nmod_poly_mat_clear(appbas2);
+    nmod_poly_mat_clear(residual);
+}
+
+
+
+
 
 
 

--- a/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
+++ b/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
@@ -30,7 +30,7 @@ void nmod_poly_mat_mbasis(nmod_poly_mat_t appbas,
     nmod_mat_poly_clear(app);
 }
 
-void nmod_poly_mat_pmbasis(nmod_poly_mat_t appbas,
+void nmod_poly_mat_pmbasis_old(nmod_poly_mat_t appbas,
                            slong * shift,
                            const nmod_poly_mat_t pmat,
                            slong order)
@@ -59,3 +59,41 @@ void nmod_poly_mat_pmbasis(nmod_poly_mat_t appbas,
     nmod_poly_mat_clear(appbas2);
     nmod_poly_mat_clear(residual);
 }
+
+void nmod_poly_mat_pmbasis(nmod_poly_mat_t appbas,
+                           slong * shift,
+                           const nmod_poly_mat_t ipmat,
+                           slong order)
+{
+
+    nmod_poly_mat_t pmat;
+
+    nmod_poly_mat_init(pmat, ipmat->r, ipmat->c, ipmat->modulus);
+    nmod_poly_mat_set_trunc(pmat,ipmat,order);
+
+    if (order <= PMBASIS_THRES)
+    {
+        nmod_poly_mat_mbasis(appbas, shift, pmat, order);
+        return;
+    }
+
+    const long order1 = order>>1;
+    const long order2 = order - order1;
+    nmod_poly_mat_t appbas2, residual;
+
+    nmod_poly_mat_init(appbas2, pmat->r, pmat->r, pmat->modulus);
+    nmod_poly_mat_init(residual, pmat->r, pmat->c, pmat->modulus);
+
+    nmod_poly_mat_pmbasis(appbas, shift, pmat, order1);
+
+    nmod_poly_mat_middle_product_naive(residual, appbas, pmat, order1, order2-1);
+
+    nmod_poly_mat_pmbasis(appbas2, shift, residual, order2);
+
+    nmod_poly_mat_mul(appbas, appbas2, appbas);
+
+    nmod_poly_mat_clear(appbas2);
+    nmod_poly_mat_clear(residual);
+}
+
+

--- a/flint-extras/src/nmod_poly_mat_extra/middle_product.c
+++ b/flint-extras/src/nmod_poly_mat_extra/middle_product.c
@@ -41,7 +41,6 @@ void nmod_poly_mat_middle_product_naive(nmod_poly_mat_t C, const nmod_poly_mat_t
                                          const nmod_poly_mat_t B, const ulong d1, const ulong d2)
 {
     slong degA;
-
     degA=nmod_poly_mat_degree(A);
     
     nmod_poly_mat_t BT;

--- a/flint-extras/src/nmod_poly_mat_extra/middle_product.c
+++ b/flint-extras/src/nmod_poly_mat_extra/middle_product.c
@@ -22,12 +22,37 @@
  *  output can alias input
  *  naive implementation (multiply, shift, truncate)
  */
-void nmod_poly_mat_middle_product_naive(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
+void nmod_poly_mat_middle_product_naive_old(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
                                         const ulong dA, const ulong dB)
 {
     nmod_poly_mat_mul(C, A, B);
     nmod_poly_mat_shift_right(C, C, dA);
     nmod_poly_mat_truncate(C, dB + 1);
+}
+
+
+/** Middle product for polynomial matrices
+ *  sets C = ((A * B) div x^d1) mod x^(d2+1), assuming deg(A) <= d1 and deg(B) <= d1 + d2
+ *  output can alias input
+ *  naive implementation (multiply, shift, truncate)
+ */
+
+void nmod_poly_mat_middle_product_naive(nmod_poly_mat_t C, const nmod_poly_mat_t A,\
+                                         const nmod_poly_mat_t B, const ulong d1, const ulong d2)
+{
+    slong degA;
+
+    degA=nmod_poly_mat_degree(A);
+    
+    nmod_poly_mat_t BT;
+    nmod_poly_mat_init(BT, A->c, B->c, B->modulus);
+    nmod_poly_mat_shift_right(BT, B, d1-degA);
+
+    nmod_poly_mat_mul(C,A,BT);  
+       
+    nmod_poly_mat_shift_right(C, C, degA);
+
+    nmod_poly_mat_truncate(C, d2+1);
 }
 
 

--- a/flint-extras/src/nmod_poly_mat_extra/middle_product.c
+++ b/flint-extras/src/nmod_poly_mat_extra/middle_product.c
@@ -37,6 +37,8 @@ void nmod_poly_mat_mulmid_naive(nmod_poly_mat_t C, const nmod_poly_mat_t A,\
     
     nmod_poly_mat_t BT;
     nmod_poly_mat_init(BT, A->c, B->c, B->modulus);
+
+    // GV to see if nlo < deg A for ASan ? 
     nmod_poly_mat_shift_right(BT, B, nlo-degA); // No aliasing specified for that?
 
     nmod_poly_mat_mul(C,A,BT);  
@@ -69,6 +71,7 @@ void nmod_poly_mat_mulmid_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A,
     
     nmod_poly_mat_t BT;
     nmod_poly_mat_init(BT, A->c, B->c, B->modulus);
+    // GV to see if nlo < deg A for ASan ?
     nmod_poly_mat_shift_right(BT, B, nlo-degA); // No aliasing specified for that?
 
     if (degA < 4)

--- a/flint-extras/src/nmod_poly_mat_extra/middle_product.c
+++ b/flint-extras/src/nmod_poly_mat_extra/middle_product.c
@@ -88,7 +88,6 @@ void nmod_poly_mat_middle_product_linearized(nmod_poly_mat_t C, const nmod_poly_
         nmod_poly_mat_mul_linearized(C,A,BT); 
     }
 
-    nmod_poly_mat_mul(C,A,BT);  
     nmod_poly_mat_shift_right(C, C, degA);  
     nmod_poly_mat_truncate(C, d2+1);
 

--- a/flint-extras/src/nmod_poly_mat_extra/middle_product.c
+++ b/flint-extras/src/nmod_poly_mat_extra/middle_product.c
@@ -47,9 +47,10 @@ void nmod_poly_mat_mulmid_naive(nmod_poly_mat_t C, const nmod_poly_mat_t A,\
 }
 
 /** Middle product for polynomial matrices
- *  sets C = ((A * B) div x^d1) mod x^(d2+1), assuming deg(A) <= d1 and deg(B) <= d1 + d2
- *  output can alias input
- *  naive implementation (multiply, shift, truncate)
+ *  
+ *  sets C to the first nhi - nlo middle coefficients of the product of A of
+ *  length len1 and B of length len2 starting at offset nlo
+ 
  * 
  *  todo: rewrite if aliasing ok with nmod_poly_mat_shift_right and others 
  * 
@@ -60,15 +61,15 @@ void nmod_poly_mat_mulmid_naive(nmod_poly_mat_t C, const nmod_poly_mat_t A,\
  *  Todo ASSUMPTION (not checked): existence of element of "large enough" order
  *           and fail flag when element not found 
  */
-void nmod_poly_mat_middle_product_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A,\
-                                         const nmod_poly_mat_t B, const ulong d1, const ulong d2)
+void nmod_poly_mat_mulmid_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A,\
+                                         const nmod_poly_mat_t B, const ulong nlo, const ulong nhi)
 {
     slong degA;
     degA=nmod_poly_mat_degree(A);
     
     nmod_poly_mat_t BT;
     nmod_poly_mat_init(BT, A->c, B->c, B->modulus);
-    nmod_poly_mat_shift_right(BT, B, d1-degA); // No aliasing specified for that?
+    nmod_poly_mat_shift_right(BT, B, nlo-degA); // No aliasing specified for that?
 
     if (degA < 4)
     {
@@ -80,7 +81,7 @@ void nmod_poly_mat_middle_product_linearized(nmod_poly_mat_t C, const nmod_poly_
     }
 
     nmod_poly_mat_shift_right(C, C, degA);  
-    nmod_poly_mat_truncate(C, d2+1);
+    nmod_poly_mat_truncate(C, nhi-nlo);
 
     nmod_poly_mat_clear(BT);
 }

--- a/flint-extras/src/nmod_poly_mat_extra/middle_product.c
+++ b/flint-extras/src/nmod_poly_mat_extra/middle_product.c
@@ -22,36 +22,12 @@
  *  output can alias input
  *  naive implementation (multiply, shift, truncate)
  */
-void nmod_poly_mat_middle_product_naive_old(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
+void nmod_poly_mat_middle_product_naive(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
                                         const ulong dA, const ulong dB)
 {
     nmod_poly_mat_mul(C, A, B);
     nmod_poly_mat_shift_right(C, C, dA);
     nmod_poly_mat_truncate(C, dB + 1);
-}
-
-
-/** Middle product for polynomial matrices
- *  sets C = ((A * B) div x^d1) mod x^(d2+1), assuming deg(A) <= d1 and deg(B) <= d1 + d2
- *  output can alias input
- *  naive implementation (multiply, shift, truncate)
- */
-
-void nmod_poly_mat_middle_product_naive(nmod_poly_mat_t C, const nmod_poly_mat_t A,\
-                                         const nmod_poly_mat_t B, const ulong d1, const ulong d2)
-{
-    slong degA;
-    degA=nmod_poly_mat_degree(A);
-    
-    nmod_poly_mat_t BT;
-    nmod_poly_mat_init(BT, A->c, B->c, B->modulus);
-    nmod_poly_mat_shift_right(BT, B, d1-degA); // No aliasing specified for that?
-
-    nmod_poly_mat_mul(C,A,BT);  
-    nmod_poly_mat_shift_right(C, C, degA);  
-    nmod_poly_mat_truncate(C, d2+1);
-
-    nmod_poly_mat_clear(BT);
 }
 
 

--- a/flint-extras/src/nmod_poly_mat_extra/middle_product.c
+++ b/flint-extras/src/nmod_poly_mat_extra/middle_product.c
@@ -45,13 +45,13 @@ void nmod_poly_mat_middle_product_naive(nmod_poly_mat_t C, const nmod_poly_mat_t
     
     nmod_poly_mat_t BT;
     nmod_poly_mat_init(BT, A->c, B->c, B->modulus);
-    nmod_poly_mat_shift_right(BT, B, d1-degA);
+    nmod_poly_mat_shift_right(BT, B, d1-degA); // No aliasing specified for that?
 
     nmod_poly_mat_mul(C,A,BT);  
-       
-    nmod_poly_mat_shift_right(C, C, degA);
-
+    nmod_poly_mat_shift_right(C, C, degA);  
     nmod_poly_mat_truncate(C, d2+1);
+
+    nmod_poly_mat_clear(BT);
 }
 
 

--- a/flint-extras/src/nmod_poly_mat_extra/middle_product.c
+++ b/flint-extras/src/nmod_poly_mat_extra/middle_product.c
@@ -19,7 +19,7 @@
 
 /** Middle product for polynomial matrices
  *  sets C = ((A * B) div x^dA) mod x^(dB+1), assuming deg(A) <= dA and deg(B) <= dA + dB
- *  output can alias input
+ *  output can alias input 
  *  naive implementation (multiply, shift, truncate)
  */
 void nmod_poly_mat_middle_product_naive_old(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
@@ -35,8 +35,9 @@ void nmod_poly_mat_middle_product_naive_old(nmod_poly_mat_t C, const nmod_poly_m
  *  sets C = ((A * B) div x^d1) mod x^(d2+1), assuming deg(A) <= d1 and deg(B) <= d1 + d2
  *  output can alias input
  *  naive implementation (multiply, shift, truncate)
+ * 
+ *  todo: rewrite if aliasing ok with nmod_poly_mat_shift_right and others 
  */
-
 void nmod_poly_mat_middle_product_naive(nmod_poly_mat_t C, const nmod_poly_mat_t A,\
                                          const nmod_poly_mat_t B, const ulong d1, const ulong d2)
 {
@@ -45,7 +46,47 @@ void nmod_poly_mat_middle_product_naive(nmod_poly_mat_t C, const nmod_poly_mat_t
     
     nmod_poly_mat_t BT;
     nmod_poly_mat_init(BT, A->c, B->c, B->modulus);
+    nmod_poly_mat_shift_right(BT, B, d1-degA); // No aliasing specified for that in flint?
+
+    nmod_poly_mat_mul(C,A,BT);  
+    nmod_poly_mat_shift_right(C, C, degA);  
+    nmod_poly_mat_truncate(C, d2+1);
+
+    nmod_poly_mat_clear(BT);
+}
+
+/** Middle product for polynomial matrices
+ *  sets C = ((A * B) div x^d1) mod x^(d2+1), assuming deg(A) <= d1 and deg(B) <= d1 + d2
+ *  output can alias input
+ *  naive implementation (multiply, shift, truncate)
+ * 
+ *  todo: rewrite if aliasing ok with nmod_poly_mat_shift_right and others 
+ * 
+ *  todo: threshold for use of linearization 
+ * 
+ *  uses geometric multiplication 
+ *  
+ *  Todo ASSUMPTION (not checked): existence of element of "large enough" order
+ *           and fail flag when element not found 
+ */
+void nmod_poly_mat_middle_product_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A,\
+                                         const nmod_poly_mat_t B, const ulong d1, const ulong d2)
+{
+    slong degA;
+    degA=nmod_poly_mat_degree(A);
+    
+    nmod_poly_mat_t BT;
+    nmod_poly_mat_init(BT, A->c, B->c, B->modulus);
     nmod_poly_mat_shift_right(BT, B, d1-degA); // No aliasing specified for that?
+
+    if (degA < 4)
+    {
+        nmod_poly_mat_mul(C,A,BT);  
+    }
+    else
+    {
+        nmod_poly_mat_mul_linearized(C,A,BT); 
+    }
 
     nmod_poly_mat_mul(C,A,BT);  
     nmod_poly_mat_shift_right(C, C, degA);  

--- a/flint-extras/src/nmod_poly_mat_extra/mul_linearized.c
+++ b/flint-extras/src/nmod_poly_mat_extra/mul_linearized.c
@@ -130,8 +130,9 @@ void static compress_columns(nmod_poly_mat_t A, const slong* colAL,\
  * 
  *  Linearizes B by columns into chunks of length deg(A) + 1
  * 
- *  TODO ASSUMPTION (not checked): existence of element of "large enough" order
+ *  Todo ASSUMPTION (not checked): existence of element of "large enough" order
  *           and fail flag when element not found
+ *  Todo  no linearization in certain cases ?  
  *  
  */
 
@@ -160,14 +161,11 @@ void nmod_poly_mat_mul_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, co
     slong chunk; 
     chunk = (nmod_poly_mat_degree(A)+1);
 
-
     slong dB[n];
     nmod_poly_mat_column_degree(dB, B, NULL);
 
-    // dim of new cols 
-
-    slong colBL[m];
-    slong ln=0;
+    slong colBL[m];  // column j of B gives colBL[j] columns in output  
+    slong ln=0;   // new column dimension 
 
     for (int j=0; j<n; j++)
     {
@@ -180,20 +178,16 @@ void nmod_poly_mat_mul_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, co
 
     spread_columns(lin_B, colBL, B, chunk); 
 
-
     nmod_poly_mat_t lin_C;
     nmod_poly_mat_init(lin_C, m, ln, A->modulus);
 
-
-    //nmod_poly_mat_mul(lin_C,A,lin_B);
     nmod_poly_mat_mul_geometric(lin_C,A,lin_B);
 
     compress_columns(C, colBL, lin_C, chunk); 
 
+    nmod_poly_mat_clear(lin_B);
+    nmod_poly_mat_clear(lin_C);
 }
-
-
-
 
 
 

--- a/flint-extras/src/nmod_poly_mat_extra/mul_linearized.c
+++ b/flint-extras/src/nmod_poly_mat_extra/mul_linearized.c
@@ -137,17 +137,18 @@ void static compress_columns(nmod_poly_mat_t A, const slong* colAL,\
 
 void nmod_poly_mat_mul_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B)
 {
-
     slong m = A->r;
     slong l = A->c;
     slong n = B->c;
 
-    if (m < 1 || (A->c) < 1 || n < 1)
+    if (m < 1 || (A->c) < 1 || n < 1 || nmod_poly_mat_is_zero(B))
     {
         nmod_poly_mat_zero(C);
         return;
     }
 
+    /** Really needed for aliasing?
+     */
     if (C == A || C == B)
     {
         nmod_poly_mat_t T;
@@ -158,8 +159,16 @@ void nmod_poly_mat_mul_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, co
         return;
     }
 
+    /** the chunk could be adapted 
+     */
     slong chunk; 
     chunk = (nmod_poly_mat_degree(A)+1);
+
+    if ((nmod_poly_mat_degree(B)+1) <= chunk)
+    {  
+        nmod_poly_mat_mul(C,A,B);
+        return;
+    }
 
     slong dB[n];
     nmod_poly_mat_column_degree(dB, B, NULL);
@@ -173,29 +182,20 @@ void nmod_poly_mat_mul_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, co
         ln += colBL[j];
     }
 
-    if (ln == 0)
-    {
-        nmod_poly_mat_zero(C);
-        return;
-    }
-    else 
-    {
-        nmod_poly_mat_t lin_B;
-        nmod_poly_mat_init(lin_B, l, ln, A->modulus);
+    nmod_poly_mat_t lin_B;
+    nmod_poly_mat_init(lin_B, l, ln, A->modulus);
 
-        spread_columns(lin_B, colBL, B, chunk); 
+    spread_columns(lin_B, colBL, B, chunk); 
 
-        nmod_poly_mat_t lin_C;
-        nmod_poly_mat_init(lin_C, m, ln, A->modulus);
+    nmod_poly_mat_t lin_C;
+    nmod_poly_mat_init(lin_C, m, ln, A->modulus);
 
-        nmod_poly_mat_mul_geometric(lin_C,A,lin_B);
+    nmod_poly_mat_mul_geometric(lin_C,A,lin_B);
 
-        compress_columns(C, colBL, lin_C, chunk); 
+    compress_columns(C, colBL, lin_C, chunk); 
 
-        nmod_poly_mat_clear(lin_B);
-        nmod_poly_mat_clear(lin_C);
-    }
-    
+    nmod_poly_mat_clear(lin_B);
+    nmod_poly_mat_clear(lin_C);
 }
 
 

--- a/flint-extras/src/nmod_poly_mat_extra/mul_linearized.c
+++ b/flint-extras/src/nmod_poly_mat_extra/mul_linearized.c
@@ -173,7 +173,7 @@ void nmod_poly_mat_mul_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, co
     slong dB[n];
     nmod_poly_mat_column_degree(dB, B, NULL);
 
-    slong colBL[m];  // column j of B gives colBL[j] columns in output  
+    slong colBL[n];  // column j of B gives colBL[j] columns in output  
     slong ln=0;   // new column dimension 
 
     for (int j=0; j<n; j++)

--- a/flint-extras/src/nmod_poly_mat_extra/mul_linearized.c
+++ b/flint-extras/src/nmod_poly_mat_extra/mul_linearized.c
@@ -9,6 +9,7 @@
     License, or (at your option) any later version. See
     <https://www.gnu.org/licenses/>.
 */
+#include <math.h>
 
 #include <flint/nmod.h>
 #include <flint/nmod_vec.h>
@@ -19,6 +20,7 @@
 #include "nmod_extra.h" // for nmod_find_root
 
 #include "nmod_poly_mat_multiply.h"
+#include "nmod_poly_mat_forms.h"
 
 
 
@@ -28,7 +30,7 @@
  */
 
 
-void spread_columns(nmod_poly_mat_t lin_A, const slong* colAL,\
+void static spread_columns(nmod_poly_mat_t lin_A, const slong* colAL,\
                 const nmod_poly_mat_t A, const slong chunk)
 {
     int i,j,l;
@@ -49,9 +51,7 @@ void spread_columns(nmod_poly_mat_t lin_A, const slong* colAL,\
        {
             for (i=0; i<m; i++) 
             {
-            
                 nmod_poly_set(tpol, nmod_poly_mat_entry(A, i, j));
-
                 nmod_poly_set_trunc(nmod_poly_mat_entry(lin_A, i, dec),tpol,chunk);
 
                 for (l=1; l<colAL[j]; l++) 
@@ -70,17 +70,128 @@ void spread_columns(nmod_poly_mat_t lin_A, const slong* colAL,\
             dec+=colAL[j];
         }
     }
+
+    nmod_poly_clear(tpol);
 }
 
            
+/** The columns of lin_A are compressed to give A  
+ *    colAL[j] chunks of length 'chunk' give the column j in A 
+ */
+
+void static compress_columns(nmod_poly_mat_t A, const slong* colAL,\
+                const nmod_poly_mat_t lin_A, const slong chunk)
+{
+    int i,j,l;
+
+    slong m = A->r;
+    slong n = A->c; 
+
+    nmod_poly_t tpol,taccu;
+    nmod_poly_init(tpol,A->modulus);
+    nmod_poly_init(taccu,A->modulus);
+
+    slong dec=0;
+
+    nmod_poly_mat_zero(A);
+
+    for (j=0; j<n; j++) 
+    {
+       /** to see: loop in another way for efficiency */
+       if (colAL[j] > 0)
+       {
+            for (i=0; i<m; i++) 
+            {
+                nmod_poly_set(taccu, nmod_poly_mat_entry(lin_A, i, dec));
+
+                for (l=1; l<colAL[j]; l++) 
+                {
+                    nmod_poly_shift_left(tpol, \
+                        nmod_poly_mat_entry(lin_A, i, dec+l), l*chunk);
+                    nmod_poly_add(taccu, taccu, tpol);
+                }
+
+                nmod_poly_set(nmod_poly_mat_entry(A, i, j), taccu);
+            }
+
+            dec+=colAL[j];
+        }
+    }
+
+    nmod_poly_clear(tpol);
+    nmod_poly_clear(taccu);
+}
+
+
 /** Multiplication for polynomial matrices
  *  sets C = A * B
- *  
- *  TODO outputt can alias input 
+ *  output can alias input 
+ *  uses mul_geometric 
+ * 
+ *  Linearizes B by columns into chunks of length deg(A) + 1
+ * 
  *  TODO ASSUMPTION (not checked): existence of element of "large enough" order
- *  TODO -> fail flag when element not found
+ *           and fail flag when element not found
  *  
  */
+
+void nmod_poly_mat_mul_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B)
+{
+
+    slong m = A->r;
+    slong n = B->c;
+
+    if (m < 1 || A->c || n < 1)
+    {
+        nmod_poly_mat_zero(C);
+        return;
+    }
+
+    if (C == A || C == B)
+    {
+        nmod_poly_mat_t T;
+        nmod_poly_mat_init(T, m, n, A->modulus);
+        nmod_poly_mat_mul_linearized(T, A, B);
+        nmod_poly_mat_swap_entrywise(C, T);
+        nmod_poly_mat_clear(T);
+        return;
+    }
+
+    slong chunk; 
+    chunk = (nmod_poly_mat_degree(A)+1);
+
+
+    slong dB[n];
+    nmod_poly_mat_column_degree(dB, B, NULL);
+
+    // dim of new cols 
+
+    slong colBL[m];
+    slong ln=0;
+
+    for (int j=0; j<n; j++)
+    {
+        colBL[j] = ceil((double) (dB[j]+1)/chunk);
+        ln += colBL[j];
+    }
+
+    nmod_poly_mat_t lin_B;
+    nmod_poly_mat_init(lin_B, m, ln, A->modulus);
+
+    spread_columns(lin_B, colBL, B, chunk); 
+
+
+    nmod_poly_mat_t lin_C;
+    nmod_poly_mat_init(lin_C, m, ln, A->modulus);
+
+
+    //nmod_poly_mat_mul(lin_C,A,lin_B);
+    nmod_poly_mat_mul_geometric(lin_C,A,lin_B);
+
+    compress_columns(C, colBL, lin_C, chunk); 
+
+}
+
 
 
 

--- a/flint-extras/src/nmod_poly_mat_extra/mul_linearized.c
+++ b/flint-extras/src/nmod_poly_mat_extra/mul_linearized.c
@@ -161,6 +161,8 @@ void nmod_poly_mat_mul_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, co
     slong chunk; 
     chunk = (nmod_poly_mat_degree(A)+1);
 
+    flint_printf("\n\n chunk: %ld\n",chunk);
+
     slong dB[n];
     nmod_poly_mat_column_degree(dB, B, NULL);
 

--- a/flint-extras/src/nmod_poly_mat_extra/mul_linearized.c
+++ b/flint-extras/src/nmod_poly_mat_extra/mul_linearized.c
@@ -1,0 +1,88 @@
+/*
+    Copyright (C) 2026 Gilles Villard
+
+    This file is part of PML.
+
+    PML is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License version 2.0 (GPL-2.0-or-later)
+    as published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version. See
+    <https://www.gnu.org/licenses/>.
+*/
+
+#include <flint/nmod.h>
+#include <flint/nmod_vec.h>
+#include <flint/nmod_mat.h>
+#include <flint/nmod_poly.h>
+#include <flint/nmod_poly_mat.h>
+
+#include "nmod_extra.h" // for nmod_find_root
+
+#include "nmod_poly_mat_multiply.h"
+
+
+
+/** Spreads the columns of A into chunks of length 'chunk' 
+ *   for each column j of A there are colAL[j] new created columns,
+ *   lin_A has been initialized outside with the correct dimensions
+ */
+
+
+void spread_columns(nmod_poly_mat_t lin_A, const slong* colAL,\
+                const nmod_poly_mat_t A, const slong chunk)
+{
+    int i,j,l;
+
+    slong m = A->r;
+    slong n = A->c; 
+
+    nmod_poly_t tpol;
+    nmod_poly_init(tpol,A->modulus);
+
+    slong dec=0;
+
+    /** on the columns of A */
+    for (j=0; j<n; j++) 
+    {
+       /** to see: loop in another way for efficiency */
+       if (colAL[j] > 0)
+       {
+            for (i=0; i<m; i++) 
+            {
+            
+                nmod_poly_set(tpol, nmod_poly_mat_entry(A, i, j));
+
+                nmod_poly_set_trunc(nmod_poly_mat_entry(lin_A, i, dec),tpol,chunk);
+
+                for (l=1; l<colAL[j]; l++) 
+                {
+                    if (chunk <= nmod_poly_degree(tpol)+1)
+                    {
+                        nmod_poly_shift_right(tpol,tpol,chunk);
+                        nmod_poly_set_trunc(nmod_poly_mat_entry(lin_A, i, dec+l),tpol,chunk);
+                    }
+                    else 
+                    {
+                        nmod_poly_zero(nmod_poly_mat_entry(lin_A, i, dec+l));
+                    }
+                }
+            }
+            dec+=colAL[j];
+        }
+    }
+}
+
+           
+/** Multiplication for polynomial matrices
+ *  sets C = A * B
+ *  
+ *  TODO outputt can alias input 
+ *  TODO ASSUMPTION (not checked): existence of element of "large enough" order
+ *  TODO -> fail flag when element not found
+ *  
+ */
+
+
+
+
+

--- a/flint-extras/src/nmod_poly_mat_extra/mul_linearized.c
+++ b/flint-extras/src/nmod_poly_mat_extra/mul_linearized.c
@@ -106,8 +106,7 @@ void static compress_columns(nmod_poly_mat_t A, const slong* colAL,\
 
                 for (l=1; l<colAL[j]; l++) 
                 {
-                    nmod_poly_shift_left(tpol, \
-                        nmod_poly_mat_entry(lin_A, i, dec+l), l*chunk);
+                    nmod_poly_shift_left(tpol,nmod_poly_mat_entry(lin_A, i, dec+l), l*chunk);
                     nmod_poly_add(taccu, taccu, tpol);
                 }
 
@@ -140,9 +139,10 @@ void nmod_poly_mat_mul_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, co
 {
 
     slong m = A->r;
+    slong l = A->c;
     slong n = B->c;
 
-    if (m < 1 || A->c || n < 1)
+    if (m < 1 || (A->c) < 1 || n < 1)
     {
         nmod_poly_mat_zero(C);
         return;
@@ -161,8 +161,6 @@ void nmod_poly_mat_mul_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, co
     slong chunk; 
     chunk = (nmod_poly_mat_degree(A)+1);
 
-    flint_printf("\n\n chunk: %ld\n",chunk);
-
     slong dB[n];
     nmod_poly_mat_column_degree(dB, B, NULL);
 
@@ -175,20 +173,29 @@ void nmod_poly_mat_mul_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, co
         ln += colBL[j];
     }
 
-    nmod_poly_mat_t lin_B;
-    nmod_poly_mat_init(lin_B, m, ln, A->modulus);
+    if (ln == 0)
+    {
+        nmod_poly_mat_zero(C);
+        return;
+    }
+    else 
+    {
+        nmod_poly_mat_t lin_B;
+        nmod_poly_mat_init(lin_B, l, ln, A->modulus);
 
-    spread_columns(lin_B, colBL, B, chunk); 
+        spread_columns(lin_B, colBL, B, chunk); 
 
-    nmod_poly_mat_t lin_C;
-    nmod_poly_mat_init(lin_C, m, ln, A->modulus);
+        nmod_poly_mat_t lin_C;
+        nmod_poly_mat_init(lin_C, m, ln, A->modulus);
 
-    nmod_poly_mat_mul_geometric(lin_C,A,lin_B);
+        nmod_poly_mat_mul_geometric(lin_C,A,lin_B);
 
-    compress_columns(C, colBL, lin_C, chunk); 
+        compress_columns(C, colBL, lin_C, chunk); 
 
-    nmod_poly_mat_clear(lin_B);
-    nmod_poly_mat_clear(lin_C);
+        nmod_poly_mat_clear(lin_B);
+        nmod_poly_mat_clear(lin_C);
+    }
+    
 }
 
 

--- a/flint-extras/src/nmod_poly_mat_extra/test/main.c
+++ b/flint-extras/src/nmod_poly_mat_extra/test/main.c
@@ -24,6 +24,7 @@
 #include "t-mul_linearized.c"
 #include "t-mbasis.c"
 #include "t-pmbasis.c"
+#include "t-pmbasis_linearized.c"
 #include "t-mul_waksman.c"
 #include "t-rand.c"
 #include "t-weak_popov_form.c"
@@ -42,6 +43,7 @@ test_struct tests[] =
     TEST_FUNCTION(nmod_poly_mat_mul_geometric),
     TEST_FUNCTION(nmod_poly_mat_mul_linearized),
     TEST_FUNCTION(nmod_poly_mat_pmbasis),
+    TEST_FUNCTION(nmod_poly_mat_pmbasis_linearized),
     /* TEST_FUNCTION(nmod_poly_mat_mul_waksman), */  /* TODO */
     TEST_FUNCTION(nmod_poly_mat_rand),
     TEST_FUNCTION(nmod_poly_mat_weak_popov_form),

--- a/flint-extras/src/nmod_poly_mat_extra/test/main.c
+++ b/flint-extras/src/nmod_poly_mat_extra/test/main.c
@@ -19,6 +19,7 @@
 #include "t-hermite_normal_form.c"
 #include "t-kernel.c"
 #include "t-middle_product_geometric.c"
+#include "t-middle_product_linearized.c"
 #include "t-mul_geometric.c"
 #include "t-mul_linearized.c"
 #include "t-mbasis.c"
@@ -37,6 +38,7 @@ test_struct tests[] =
     TEST_FUNCTION(nmod_poly_mat_kernel),
     TEST_FUNCTION(nmod_poly_mat_mbasis),
     TEST_FUNCTION(nmod_poly_mat_middle_product_geometric),
+    TEST_FUNCTION(nmod_poly_mat_middle_product_linearized),
     TEST_FUNCTION(nmod_poly_mat_mul_geometric),
     TEST_FUNCTION(nmod_poly_mat_mul_linearized),
     TEST_FUNCTION(nmod_poly_mat_pmbasis),

--- a/flint-extras/src/nmod_poly_mat_extra/test/main.c
+++ b/flint-extras/src/nmod_poly_mat_extra/test/main.c
@@ -20,6 +20,7 @@
 #include "t-kernel.c"
 #include "t-middle_product_geometric.c"
 #include "t-mul_geometric.c"
+#include "t-mul_linearized.c"
 #include "t-mbasis.c"
 #include "t-pmbasis.c"
 #include "t-mul_waksman.c"
@@ -37,6 +38,7 @@ test_struct tests[] =
     TEST_FUNCTION(nmod_poly_mat_mbasis),
     TEST_FUNCTION(nmod_poly_mat_middle_product_geometric),
     TEST_FUNCTION(nmod_poly_mat_mul_geometric),
+    TEST_FUNCTION(nmod_poly_mat_mul_linearized),
     TEST_FUNCTION(nmod_poly_mat_pmbasis),
     /* TEST_FUNCTION(nmod_poly_mat_mul_waksman), */  /* TODO */
     TEST_FUNCTION(nmod_poly_mat_rand),

--- a/flint-extras/src/nmod_poly_mat_extra/test/t-middle_product_linearized.c
+++ b/flint-extras/src/nmod_poly_mat_extra/test/t-middle_product_linearized.c
@@ -21,7 +21,7 @@
 /*--------------------------------------------------------------*/
 /* middle product using different implementations               */
 /*--------------------------------------------------------------*/
-int test_mat_middle_product_linearized(ulong bits, ulong m, ulong n, ulong p, ulong deg, flint_rand_t state)
+int test_mat_mulmid_linearized(ulong bits, ulong m, ulong n, ulong p, ulong deg, flint_rand_t state)
 {
     ulong prime = n_randprime(state, bits, 1);
 
@@ -37,8 +37,8 @@ int test_mat_middle_product_linearized(ulong bits, ulong m, ulong n, ulong p, ul
     nmod_poly_mat_rand(C1, state, deg);
     nmod_poly_mat_rand(C2, state, deg);
 
-    nmod_poly_mat_middle_product_naive(C1, A, B, deg-1, deg-1);
-    nmod_poly_mat_middle_product_linearized(C2, A, B, deg-1, deg-1);
+    nmod_poly_mat_mulmid_naive(C1, A, B, deg-1, 2*deg-1);
+    nmod_poly_mat_mulmid_linearized(C2, A, B, deg-1, 2*deg-1);
 
     int res = nmod_poly_mat_equal(C1, C2);
     
@@ -67,7 +67,7 @@ TEST_FUNCTION_START(nmod_poly_mat_middle_product_linearized, state)
         /*              "deg = %wu, n_bits = %wu\n", */
         /*              m, n, p, deg, bits); */
 
-        result = test_mat_middle_product_linearized(bits, m, n, p, deg, state);
+        result = test_mat_mulmid_linearized(bits, m, n, p, deg, state);
 
         if (!result)
             TEST_FUNCTION_FAIL(

--- a/flint-extras/src/nmod_poly_mat_extra/test/t-middle_product_linearized.c
+++ b/flint-extras/src/nmod_poly_mat_extra/test/t-middle_product_linearized.c
@@ -1,6 +1,6 @@
 /*
-    Copyright (C) 2026 Gilles Villard 
-    from t-middle_product_geometric.
+    2026 Gilles Villard 
+    from t-middle_product_geometric.c
     Copyright (C) 2025 Vincent Neiger, Éric Schost
 
     This file is part of PML.

--- a/flint-extras/src/nmod_poly_mat_extra/test/t-middle_product_linearized.c
+++ b/flint-extras/src/nmod_poly_mat_extra/test/t-middle_product_linearized.c
@@ -1,0 +1,80 @@
+/*
+    Copyright (C) 2026 Gilles Villard 
+    from t-middle_product_geometric.
+    Copyright (C) 2025 Vincent Neiger, Éric Schost
+
+    This file is part of PML.
+
+    PML is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License version 2.0 (GPL-2.0-or-later)
+    as published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version. See
+    <https://www.gnu.org/licenses/>.
+*/
+
+#include <flint/nmod_poly_mat.h>
+#include <flint/test_helpers.h>
+
+#include "nmod_poly_mat_utils.h" // for rand
+#include "nmod_poly_mat_multiply.h"
+
+/*--------------------------------------------------------------*/
+/* middle product using different implementations               */
+/*--------------------------------------------------------------*/
+int test_mat_middle_product_linearized(ulong bits, ulong m, ulong n, ulong p, ulong deg, flint_rand_t state)
+{
+    ulong prime = n_randprime(state, bits, 1);
+
+    nmod_poly_mat_t A, B, C1, C2;
+
+    nmod_poly_mat_init(A, m, n, prime);
+    nmod_poly_mat_init(B, n, p, prime);
+    nmod_poly_mat_init(C1, m, p, prime);
+    nmod_poly_mat_init(C2, m, p, prime);
+
+    nmod_poly_mat_rand(A, state, deg);
+    nmod_poly_mat_rand(B, state, 2 * deg - 1);
+    nmod_poly_mat_rand(C1, state, deg);
+    nmod_poly_mat_rand(C2, state, deg);
+
+    nmod_poly_mat_middle_product_naive(C1, A, B, deg-1, deg-1);
+    nmod_poly_mat_middle_product_linearized(C2, A, B, deg-1, deg-1);
+
+    int res = nmod_poly_mat_equal(C1, C2);
+    
+    nmod_poly_mat_clear(C1);
+    nmod_poly_mat_clear(C2);
+    nmod_poly_mat_clear(B);
+    nmod_poly_mat_clear(A);
+   
+    return res;
+}
+
+TEST_FUNCTION_START(nmod_poly_mat_middle_product_linearized, state)
+{
+    int i, result;
+
+    for (i = 0; i < 40 * flint_test_multiplier(); i++)
+    {
+        /* FIXME field must be "large enough" : add proper test/fallback */
+        ulong bits = 16 + n_randint(state, 49);
+        ulong m = 1 + n_randint(state, 50);
+        ulong n = 1 + n_randint(state, 50);
+        ulong p = 1 + n_randint(state, 50);
+        ulong deg = 0 + n_randint(state, 50);
+
+        /* flint_printf("m = %wu, n = %wu, p = %wu\n" */
+        /*              "deg = %wu, n_bits = %wu\n", */
+        /*              m, n, p, deg, bits); */
+
+        result = test_mat_middle_product_linearized(bits, m, n, p, deg, state);
+
+        if (!result)
+            TEST_FUNCTION_FAIL(
+                    "m = %wu, n = %wu, p = %wu\n"
+                    "deg = %wu, n_bits = %wu\n",
+                    m, n, p, deg, bits);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/flint-extras/src/nmod_poly_mat_extra/test/t-mul_linearized.c
+++ b/flint-extras/src/nmod_poly_mat_extra/test/t-mul_linearized.c
@@ -1,6 +1,6 @@
 /*
-    Copyright (C) 2026 Gilles Villard, 
-         from t-mul_geometric.c
+    2026 Gilles Villard
+    from t-mul_geometric.c
     Copyright (C) 2025 Vincent Neiger, Éric Schost
 
     This file is part of PML.

--- a/flint-extras/src/nmod_poly_mat_extra/test/t-mul_linearized.c
+++ b/flint-extras/src/nmod_poly_mat_extra/test/t-mul_linearized.c
@@ -1,0 +1,83 @@
+/*
+    Copyright (C) 2026 Gilles Villard, 
+         from t-mul_geometric.c
+    Copyright (C) 2025 Vincent Neiger, Éric Schost
+
+    This file is part of PML.
+
+    PML is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License version 2.0 (GPL-2.0-or-later)
+    as published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version. See
+    <https://www.gnu.org/licenses/>.
+*/
+
+#include <flint/nmod_poly_mat.h>
+#include <flint/test_helpers.h>
+
+#include "nmod_poly_mat_utils.h" // for rand
+#include "nmod_poly_mat_multiply.h"
+
+/* TODO more primes, more variations of degrees, etc. */
+
+/*--------------------------------------------------------------*/
+/* middle product using different implementations               */
+/*--------------------------------------------------------------*/
+int test_mat_mul_linearized(ulong bits, ulong m, ulong n, ulong p, ulong deg, flint_rand_t state)
+{
+    ulong prime = n_randprime(state, bits, 1);
+
+    nmod_poly_mat_t A, B, C1, C2;
+
+    nmod_poly_mat_init(A, m, n, prime);
+    nmod_poly_mat_init(B, n, p, prime);
+    nmod_poly_mat_init(C1, m, p, prime);
+    nmod_poly_mat_init(C2, m, p, prime);
+
+    nmod_poly_mat_rand(A, state, deg);
+    nmod_poly_mat_rand(B, state, deg);
+    nmod_poly_mat_rand(C1, state, deg);
+    nmod_poly_mat_rand(C2, state, deg);
+
+    nmod_poly_mat_mul(C1, A, B);
+    nmod_poly_mat_mul_linearized(C2, A, B);
+
+    int res = nmod_poly_mat_equal(C1, C2);
+
+    nmod_poly_mat_clear(C1);
+    nmod_poly_mat_clear(C2);
+    nmod_poly_mat_clear(B);
+    nmod_poly_mat_clear(A);
+
+    return res;
+}
+
+TEST_FUNCTION_START(nmod_poly_mat_mul_linearized, state)
+{
+    int i, result;
+
+    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    {
+        /* FIXME field must be "large enough" : add proper test/fallback */
+        ulong bits = 16 + n_randint(state, 49);
+        ulong m = 1 + n_randint(state, 50);
+        ulong n = 1 + n_randint(state, 50);
+        ulong p = 1 + n_randint(state, 50);
+        ulong deg = 0 + n_randint(state, 50);
+
+        /* flint_printf("~~~ test i = %d ~~~\n" */
+        /*              "m = %wu, n = %wu, p = %wu\n" */
+        /*              "deg = %wu, n_bits = %wu\n", */
+        /*              i, m, n, p, deg, bits); */
+
+        result = test_mat_mul_linearized(bits, m, n, p, deg, state);
+
+        if (!result)
+            TEST_FUNCTION_FAIL(
+                    "m = %wu, n = %wu, p = %wu\n"
+                    "n_bits = %wu\n",
+                    m, n, p, bits);
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/flint-extras/src/nmod_poly_mat_extra/test/t-pmbasis_linearized.c
+++ b/flint-extras/src/nmod_poly_mat_extra/test/t-pmbasis_linearized.c
@@ -1,0 +1,503 @@
+/*
+    2026 Gilles Villard 
+    From  t-pmbasis.c
+    Copyright (C) 2025 Vincent Neiger
+
+    This file is part of PML.
+
+    PML is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License version 2.0 (GPL-2.0-or-later)
+    as published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version. See
+    <https://www.gnu.org/licenses/>.
+*/
+
+/**  Todo: see how to specialize shared testinfg files to various methods 
+ *    eg shared files for pmbasis and pmbasis_linearized here 
+ */
+
+
+#include <flint/test_helpers.h>
+
+#include "nmod_poly_mat_approximant.h"
+#include "nmod_poly_mat_io.h"
+
+#include "testing_collection.h"
+
+#define _TEST_VERBOSE_ 0
+
+const slong _test_collection_nb_primes_geometric = 3;
+slong _test_collection_primes_geometric[]  = {
+    549755813911, 562949953421381, 576460752303423619  // 40, 50, 60 bits
+ };
+
+
+
+// test one given input for pmbasis_linearized
+int core_test_pmbasis_linearized(nmod_poly_mat_t mat, slong order, slong * shift)
+{
+    int res = 1;
+
+    const slong rdim = mat->r;
+    nmod_poly_mat_t appbas;
+
+    slong cshift[rdim];
+    for (slong i = 0; i < rdim; i++)
+        cshift[i] = shift[i];
+
+    nmod_poly_mat_init(appbas, rdim, rdim, mat->modulus);
+    nmod_poly_mat_pmbasis_linearized(appbas, cshift, mat, order);
+
+    // testing correctness of nmod_poly_mat_pmbasis
+    if (!nmod_poly_mat_is_approximant_basis(appbas, mat, order, shift, ROW_LOWER))
+    {
+        res = 0;
+        if (0)  /* kept in case for debug */
+        {
+            printf("nmod_poly_mat_pmbasis_linearized output is not a minimal approximant basis\n");
+            printf("Input matrix:\n");
+            nmod_poly_mat_print_pretty(mat, "X");
+            printf("Output matrix:\n");
+            nmod_poly_mat_print(appbas,"X");
+            printf("Residual matrix:\n");
+            nmod_poly_mat_t res;
+            nmod_poly_mat_init(res, appbas->r, mat->c, mat->modulus);
+            nmod_poly_mat_mul(res, appbas, mat);
+            nmod_poly_mat_print_pretty(res,"X");
+            printf("Degree matrix:\n");
+            nmod_poly_mat_degree_matrix_print_pretty(appbas);
+            printf("Input shift:\t");
+            flint_printf("%{slong*}\n", shift, rdim);
+            printf("Output shift:\t");
+            flint_printf("%{slong*}\n", cshift, rdim);
+            printf("\n");
+            return 0;
+        }
+    }
+
+    nmod_poly_mat_clear(appbas);
+
+    return res;
+}
+
+/** Test with specified parameters, uniform shift */
+int one_test_pmbasis_linearized(slong prime, slong rdim, slong cdim, slong order, slong len, flint_rand_t state)
+{
+    int res;
+
+    // random matrix
+    nmod_poly_mat_t mat;
+    nmod_poly_mat_init(mat, rdim, cdim, prime);
+    nmod_poly_mat_randtest(mat, state, len);
+
+    slong * shift = flint_malloc(rdim * sizeof(slong));
+
+    _test_collection_shift_uniform(shift, rdim);
+    res = core_test_pmbasis_linearized(mat, order, shift);
+
+    _test_collection_shift_increasing(shift, rdim);
+    res = res && core_test_pmbasis_linearized(mat, order, shift);
+
+    _test_collection_shift_decreasing(shift, rdim);
+    res = res && core_test_pmbasis_linearized(mat, order, shift);
+
+    _test_collection_shift_shuffle(shift, rdim, state);
+    res = res && core_test_pmbasis_linearized(mat, order, shift);
+
+    _test_collection_shift_hermite(shift, rdim, order);
+    res = res && core_test_pmbasis_linearized(mat, order, shift);
+
+    _test_collection_shift_rhermite(shift, rdim, order);
+    res = res && core_test_pmbasis_linearized(mat, order, shift);
+
+    _test_collection_shift_plateau(shift, rdim, order);
+    res = res && core_test_pmbasis_linearized(mat, order, shift);
+
+    _test_collection_shift_rplateau(shift, rdim, order);
+    res = res && core_test_pmbasis_linearized(mat, order, shift);
+
+    nmod_poly_mat_clear(mat);
+    flint_free(shift);
+
+    return res;
+}
+
+/** Test against the whole testing collection */
+int collection_test_pmbasis_linearized(slong iter, flint_rand_t state)
+{
+    // input matrix for approximation
+    nmod_poly_mat_t mat;
+
+    // input shift
+    slong * shift;
+
+    long total_nb_tests =
+            iter  /* number of iterations */
+            * 56  /* number of mats (currently 7) x number of shifts (currently 8) */
+            * _test_collection_nb_primes_geometric
+            * _test_collection_nb_dims
+            * _test_collection_nb_dims
+            * _test_collection_nb_degs;
+    flint_printf("Launching testing collection (%ld cases)\n", total_nb_tests);
+
+    for (slong i_primes = 0; i_primes < _test_collection_nb_primes_geometric; i_primes++)
+        for (slong i_rdims = 0; i_rdims < _test_collection_nb_dims; i_rdims++)
+            for (slong i_cdims = 0; i_cdims < _test_collection_nb_dims; i_cdims++)
+                for (slong i_degs = 0; i_degs < _test_collection_nb_degs; i_degs++)
+                    for (slong it = 0; it < iter; it++)
+                    {
+                        const long prime = _test_collection_primes_geometric[i_primes];
+                        const long rdim = _test_collection_rdims[i_rdims];
+                        const long cdim = _test_collection_cdims[i_cdims];
+                        const long order = _test_collection_degs[i_degs];
+                        if (_TEST_VERBOSE_)
+                            flint_printf("prime %ld, rdim %ld, cdim %ld, order %ld.\n", prime, rdim, cdim, order);
+
+                        shift = (slong *) flint_malloc(rdim * sizeof(slong));
+                        nmod_poly_mat_init(mat, rdim, cdim, prime);
+
+                        /* uniform shift */
+                        /* matrix: zero | uniform | rdeg | cdeg | test | sparse | rkdef */
+                        _test_collection_shift_uniform(shift, rdim);
+                        _test_collection_mat_zero(mat);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "uniform", "zero"); return 0; }
+
+                        _test_collection_shift_uniform(shift, rdim);
+                        _test_collection_mat_uniform(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "uniform", "uniform"); return 0; }
+
+                        _test_collection_shift_uniform(shift, rdim);
+                        _test_collection_mat_unbalanced_rdeg(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "uniform", "unbalanced rdeg"); return 0; }
+
+                        _test_collection_shift_uniform(shift, rdim);
+                        _test_collection_mat_unbalanced_cdeg(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "uniform", "unbalanced cdeg"); return 0; }
+
+                        _test_collection_shift_uniform(shift, rdim);
+                        _test_collection_mat_test(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "uniform", "test"); return 0; }
+
+                        _test_collection_shift_uniform(shift, rdim);
+                        _test_collection_mat_sparse(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "uniform", "sparse"); return 0; }
+
+                        _test_collection_shift_uniform(shift, rdim);
+                        _test_collection_mat_rkdef(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "uniform", "rkdef"); return 0; }
+
+                        /* increasing shift */
+                        /* matrix: zero | uniform | rdeg | cdeg | test | sparse | rkdef */
+                        _test_collection_shift_increasing(shift, rdim);
+                        _test_collection_mat_zero(mat);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "increasing", "zero"); return 0; }
+
+                        _test_collection_shift_increasing(shift, rdim);
+                        _test_collection_mat_uniform(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "increasing", "uniform"); return 0; }
+
+                        _test_collection_shift_increasing(shift, rdim);
+                        _test_collection_mat_unbalanced_rdeg(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "increasing", "unbalanced rdeg"); return 0; }
+
+                        _test_collection_shift_increasing(shift, rdim);
+                        _test_collection_mat_unbalanced_cdeg(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "increasing", "unbalanced cdeg"); return 0; }
+
+                        _test_collection_shift_increasing(shift, rdim);
+                        _test_collection_mat_test(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "increasing", "test"); return 0; }
+
+                        _test_collection_shift_increasing(shift, rdim);
+                        _test_collection_mat_sparse(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "increasing", "sparse"); return 0; }
+
+                        _test_collection_shift_increasing(shift, rdim);
+                        _test_collection_mat_rkdef(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "increasing", "rkdef"); return 0; }
+
+                        /* decreasing shift */
+                        /* matrix: zero | uniform | rdeg | cdeg | test | sparse | rkdef */
+                        _test_collection_shift_decreasing(shift, rdim);
+                        _test_collection_mat_zero(mat);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "decreasing", "zero"); return 0; }
+
+                        _test_collection_shift_decreasing(shift, rdim);
+                        _test_collection_mat_uniform(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "decreasing", "uniform"); return 0; }
+
+                        _test_collection_shift_decreasing(shift, rdim);
+                        _test_collection_mat_unbalanced_rdeg(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "decreasing", "unbalanced rdeg"); return 0; }
+
+                        _test_collection_shift_decreasing(shift, rdim);
+                        _test_collection_mat_unbalanced_cdeg(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "decreasing", "unbalanced cdeg"); return 0; }
+
+                        _test_collection_shift_decreasing(shift, rdim);
+                        _test_collection_mat_test(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "decreasing", "test"); return 0; }
+
+                        _test_collection_shift_decreasing(shift, rdim);
+                        _test_collection_mat_sparse(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "decreasing", "sparse"); return 0; }
+
+                        _test_collection_shift_decreasing(shift, rdim);
+                        _test_collection_mat_rkdef(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "decreasing", "rkdef"); return 0; }
+
+                        /* shuffled shift */
+                        /* matrix: zero | uniform | rdeg | cdeg | test | sparse | rkdef */
+                        _test_collection_shift_shuffle(shift, rdim, state);
+                        _test_collection_mat_zero(mat);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "shuffle", "zero"); return 0; }
+
+                        _test_collection_shift_shuffle(shift, rdim, state);
+                        _test_collection_mat_uniform(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "shuffle", "uniform"); return 0; }
+
+                        _test_collection_shift_shuffle(shift, rdim, state);
+                        _test_collection_mat_unbalanced_rdeg(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "shuffle", "unbalanced rdeg"); return 0; }
+
+                        _test_collection_shift_shuffle(shift, rdim, state);
+                        _test_collection_mat_unbalanced_cdeg(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "shuffle", "unbalanced cdeg"); return 0; }
+
+                        _test_collection_shift_shuffle(shift, rdim, state);
+                        _test_collection_mat_test(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "shuffle", "test"); return 0; }
+
+                        _test_collection_shift_shuffle(shift, rdim, state);
+                        _test_collection_mat_sparse(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "shuffle", "sparse"); return 0; }
+
+                        _test_collection_shift_shuffle(shift, rdim, state);
+                        _test_collection_mat_rkdef(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "shuffle", "rkdef"); return 0; }
+
+                        /* HNF shift */
+                        /* matrix: zero | uniform | rdeg | cdeg | test | sparse | rkdef */
+                        _test_collection_shift_hermite(shift, rdim, order);
+                        _test_collection_mat_zero(mat);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "hermite", "zero"); return 0; }
+
+                        _test_collection_shift_hermite(shift, rdim, order);
+                        _test_collection_mat_uniform(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "hermite", "uniform"); return 0; }
+
+                        _test_collection_shift_hermite(shift, rdim, order);
+                        _test_collection_mat_unbalanced_rdeg(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "hermite", "unbalanced rdeg"); return 0; }
+
+                        _test_collection_shift_hermite(shift, rdim, order);
+                        _test_collection_mat_unbalanced_cdeg(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "hermite", "unbalanced cdeg"); return 0; }
+
+                        _test_collection_shift_hermite(shift, rdim, order);
+                        _test_collection_mat_test(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "hermite", "test"); return 0; }
+
+                        _test_collection_shift_hermite(shift, rdim, order);
+                        _test_collection_mat_sparse(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "hermite", "sparse"); return 0; }
+
+                        _test_collection_shift_hermite(shift, rdim, order);
+                        _test_collection_mat_rkdef(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "hermite", "rkdef"); return 0; }
+
+                        /* HNF shift, bis */
+                        /* matrix: zero | uniform | rdeg | cdeg | test | sparse | rkdef */
+                        _test_collection_shift_rhermite(shift, rdim, order);
+                        _test_collection_mat_zero(mat);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "rhermite", "zero"); return 0; }
+
+                        _test_collection_shift_rhermite(shift, rdim, order);
+                        _test_collection_mat_uniform(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "rhermite", "uniform"); return 0; }
+
+                        _test_collection_shift_rhermite(shift, rdim, order);
+                        _test_collection_mat_unbalanced_rdeg(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "rhermite", "unbalanced rdeg"); return 0; }
+
+                        _test_collection_shift_rhermite(shift, rdim, order);
+                        _test_collection_mat_unbalanced_cdeg(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "rhermite", "unbalanced cdeg"); return 0; }
+
+                        _test_collection_shift_rhermite(shift, rdim, order);
+                        _test_collection_mat_test(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "rhermite", "test"); return 0; }
+
+                        _test_collection_shift_rhermite(shift, rdim, order);
+                        _test_collection_mat_sparse(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "rhermite", "sparse"); return 0; }
+
+                        _test_collection_shift_rhermite(shift, rdim, order);
+                        _test_collection_mat_rkdef(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "rhermite", "rkdef"); return 0; }
+
+                        /* plateau shift */
+                        /* matrix: zero | uniform | rdeg | cdeg | test | sparse | rkdef */
+                        _test_collection_shift_plateau(shift, rdim, order);
+                        _test_collection_mat_zero(mat);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "plateau", "zero"); return 0; }
+
+                        _test_collection_shift_plateau(shift, rdim, order);
+                        _test_collection_mat_uniform(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "plateau", "uniform"); return 0; }
+
+                        _test_collection_shift_plateau(shift, rdim, order);
+                        _test_collection_mat_unbalanced_rdeg(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "plateau", "unbalanced rdeg"); return 0; }
+
+                        _test_collection_shift_plateau(shift, rdim, order);
+                        _test_collection_mat_unbalanced_cdeg(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "plateau", "unbalanced cdeg"); return 0; }
+
+                        _test_collection_shift_plateau(shift, rdim, order);
+                        _test_collection_mat_test(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "plateau", "test"); return 0; }
+
+                        _test_collection_shift_plateau(shift, rdim, order);
+                        _test_collection_mat_sparse(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "plateau", "sparse"); return 0; }
+
+                        _test_collection_shift_plateau(shift, rdim, order);
+                        _test_collection_mat_rkdef(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "plateau", "rkdef"); return 0; }
+
+                        /* plateau shift, bis */
+                        /* matrix: zero | uniform | rdeg | cdeg | test | sparse | rkdef */
+                        _test_collection_shift_rplateau(shift, rdim, order);
+                        _test_collection_mat_zero(mat);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "rplateau", "zero"); return 0; }
+
+                        _test_collection_shift_rplateau(shift, rdim, order);
+                        _test_collection_mat_uniform(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "rplateau", "uniform"); return 0; }
+
+                        _test_collection_shift_rplateau(shift, rdim, order);
+                        _test_collection_mat_unbalanced_rdeg(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "rplateau", "unbalanced rdeg"); return 0; }
+
+                        _test_collection_shift_rplateau(shift, rdim, order);
+                        _test_collection_mat_unbalanced_cdeg(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "rplateau", "unbalanced cdeg"); return 0; }
+
+                        _test_collection_shift_rplateau(shift, rdim, order);
+                        _test_collection_mat_test(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "rplateau", "test"); return 0; }
+
+                        _test_collection_shift_rplateau(shift, rdim, order);
+                        _test_collection_mat_sparse(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "rplateau", "sparse"); return 0; }
+
+                        _test_collection_shift_rplateau(shift, rdim, order);
+                        _test_collection_mat_rkdef(mat, order, state);
+                        if (! core_test_pmbasis_linearized(mat, order, shift))
+                        { flint_printf("failed %s -- %s,\n...exiting\n", "rplateau", "rkdef"); return 0; }
+
+                        nmod_poly_mat_clear(mat);
+                        flint_free(shift);
+                    }
+
+    flint_printf("--> Successful\n");
+    return 1;
+}
+
+TEST_FUNCTION_START(nmod_poly_mat_pmbasis_linearized, state)
+{
+    int i, result;
+
+    /* NOTE activate this for long test */
+    if (0)
+    {
+        for (i = 0; i < flint_test_multiplier(); i++)
+        {
+            {
+                result = collection_test_pmbasis_linearized(1, state);
+
+                if (!result)
+                    TEST_FUNCTION_FAIL("Failed pmbasis_linearized on testing collection\n");
+            }
+        }
+    }
+    else
+    {
+        for (i = 0; i < 60 * flint_test_multiplier(); i++)
+        {
+            ulong nbits = 16 + n_randint(state, 49);
+            ulong rdim = 1 + n_randint(state, 10);
+            ulong cdim = 1 + n_randint(state, 10);
+            ulong order = n_randint(state, 150);
+            ulong len = n_randint(state, 150);
+
+            slong prime = n_randprime(state, nbits, 1);
+
+            result = one_test_pmbasis_linearized(prime, rdim, cdim, order, len, state);
+
+            if (!result)
+                TEST_FUNCTION_FAIL("prime = %wu, rdim = %wu, cdim = %wu, order = %wu, len = %wu\n",
+                                   prime, rdim, cdim, order, len);
+        }
+    }
+
+    TEST_FUNCTION_END(state);
+}
+
+#undef _TEST_VERBOSE_

--- a/flint-extras/src/nmod_poly_mat_multiply.h
+++ b/flint-extras/src/nmod_poly_mat_multiply.h
@@ -105,6 +105,21 @@ void nmod_poly_mat_middle_product_naive(nmod_poly_mat_t C, const nmod_poly_mat_t
 
 
 /** Middle product for polynomial matrices
+ *  sets C = ((A * B) div x^d1) mod x^(d2+1), assuming deg(A) <= d1 and deg(B) <= d1 + d2
+ *  output can alias input
+ *  naive implementation (multiply, shift, truncate)
+ * 
+ *  uses geometric multiplication 
+ *  
+ *  Todo ASSUMPTION (not checked): existence of element of "large enough" order
+ *           and fail flag when element not found 
+ */
+void nmod_poly_mat_middle_product_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
+                                        const ulong dA, const ulong dB);
+
+
+
+/** Middle product for polynomial matrices
  *  sets C = ((A * B) div x^dA) mod x^(dB+1)
  *  output can alias input
  *  ASSUME: deg(A) <= dA and deg(B) <= dA + dB

--- a/flint-extras/src/nmod_poly_mat_multiply.h
+++ b/flint-extras/src/nmod_poly_mat_multiply.h
@@ -91,8 +91,18 @@ void nmod_poly_mat_mul_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, co
  *  output can alias input
  *  naive implementation (multiply, shift, truncate)
  */
+void nmod_poly_mat_middle_product_naive_old(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
+                                        const ulong dA, const ulong dB);
+
+
+/** Middle product for polynomial matrices
+ *  sets C = ((A * B) div x^d1) mod x^(d2+1), assuming deg(A) <= d1 and deg(B) <= d1 + d2
+ *  output can alias input
+ *  naive implementation (multiply, shift, truncate)
+ */
 void nmod_poly_mat_middle_product_naive(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
                                         const ulong dA, const ulong dB);
+
 
 /** Middle product for polynomial matrices
  *  sets C = ((A * B) div x^dA) mod x^(dB+1)

--- a/flint-extras/src/nmod_poly_mat_multiply.h
+++ b/flint-extras/src/nmod_poly_mat_multiply.h
@@ -82,7 +82,6 @@ void nmod_poly_mat_mul_waksman(nmod_poly_mat_t C, const nmod_poly_mat_t A,  cons
  *           and fail flag when element not found
  *  
  */
-
 void nmod_poly_mat_mul_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B);
 
 

--- a/flint-extras/src/nmod_poly_mat_multiply.h
+++ b/flint-extras/src/nmod_poly_mat_multiply.h
@@ -78,8 +78,9 @@ void nmod_poly_mat_mul_waksman(nmod_poly_mat_t C, const nmod_poly_mat_t A,  cons
  * 
  *  Linearizes B by columns into chunks of length deg(A) + 1
  * 
- *  TODO ASSUMPTION (not checked): existence of element of "large enough" order
+ *  Todo ASSUMPTION (not checked): existence of element of "large enough" order
  *           and fail flag when element not found
+ *  Todo  no linearization in certain cases ?  
  *  
  */
 void nmod_poly_mat_mul_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B);

--- a/flint-extras/src/nmod_poly_mat_multiply.h
+++ b/flint-extras/src/nmod_poly_mat_multiply.h
@@ -71,6 +71,19 @@ void nmod_poly_mat_mul_vdm2(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nm
  */
 void nmod_poly_mat_mul_waksman(nmod_poly_mat_t C, const nmod_poly_mat_t A,  const nmod_poly_mat_t B);
 
+/** Multiplication for polynomial matrices
+ *  sets C = A * B
+ *  output can alias input 
+ *  uses mul_geometric 
+ * 
+ *  Linearizes B by columns into chunks of length deg(A) + 1
+ * 
+ *  TODO ASSUMPTION (not checked): existence of element of "large enough" order
+ *           and fail flag when element not found
+ *  
+ */
+
+void nmod_poly_mat_mul_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B);
 
 
 /** Middle product for polynomial matrices

--- a/flint-extras/src/nmod_poly_mat_multiply.h
+++ b/flint-extras/src/nmod_poly_mat_multiply.h
@@ -102,7 +102,9 @@ void nmod_poly_mat_mulmid_naive(nmod_poly_mat_t C, const nmod_poly_mat_t A, cons
 
 
 /** Middle product for polynomial matrices
- *  sets C = ((A * B) div x^d1) mod x^(d2+1), assuming deg(A) <= d1 and deg(B) <= d1 + d2
+ *  Sets C = ((A * B mod x^nhi) div x^nlo)
+ *  i.e., sets C to the first nhi - nlo middle coefficients of the product of A
+ *  of length len1 and B of length len2 starting at offset nlo
  *  output can alias input
  *  naive implementation (multiply, shift, truncate)
  */
@@ -111,18 +113,16 @@ void nmod_poly_mat_mulmid_naive(nmod_poly_mat_t C, const nmod_poly_mat_t A, cons
 
 
 /** Middle product for polynomial matrices
- *  sets C = ((A * B) div x^d1) mod x^(d2+1), assuming deg(A) <= d1 and deg(B) <= d1 + d2
- *  output can alias input
- *  naive implementation (multiply, shift, truncate)
- * 
+ *  Sets C = ((A * B mod x^nhi) div x^nlo)
+ *  i.e., sets C to the first nhi - nlo middle coefficients of the product of A
+ *  of length len1 and B of length len2 starting at offset nlo
  *  uses geometric multiplication 
  *  
  *  Todo ASSUMPTION (not checked): existence of element of "large enough" order
  *           and fail flag when element not found 
  */
-void nmod_poly_mat_middle_product_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
-                                        const ulong dA, const ulong dB);
-
+void nmod_poly_mat_mulmid_linearized(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
+                                        const ulong nlo, const ulong nhi);
 
 
 /** Middle product for polynomial matrices

--- a/flint-extras/src/nmod_poly_mat_multiply.h
+++ b/flint-extras/src/nmod_poly_mat_multiply.h
@@ -78,18 +78,8 @@ void nmod_poly_mat_mul_waksman(nmod_poly_mat_t C, const nmod_poly_mat_t A,  cons
  *  output can alias input
  *  naive implementation (multiply, shift, truncate)
  */
-void nmod_poly_mat_middle_product_naive_old(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
-                                        const ulong dA, const ulong dB);
-
-
-/** Middle product for polynomial matrices
- *  sets C = ((A * B) div x^d1) mod x^(d2+1), assuming deg(A) <= d1 and deg(B) <= d1 + d2
- *  output can alias input
- *  naive implementation (multiply, shift, truncate)
- */
 void nmod_poly_mat_middle_product_naive(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
                                         const ulong dA, const ulong dB);
-
 
 /** Middle product for polynomial matrices
  *  sets C = ((A * B) div x^dA) mod x^(dB+1)


### PR DESCRIPTION
New procedure `nmod_poly_mat_pmbasis_linearized` from `nmod_poly_mat_pmbasis` by changing the matrix multiplications involved. 
Relies on new procedures for linearized matrix product. 

Relies on https://github.com/vneiger/pml/pull/40 that seems to improve timings in the vast majority of cases. 

- `nmod_poly_mat_mul_linearized`  for a product A(x).B(x), linearizes the columns of B into chunks of length related to the degree of A (to be tuned);
- `nmod_poly_mat_middle_product_linearized`, uses `nmod_poly_mat_mul_linearized`;
- the product of intermediate bases relies on `nmod_poly_mat_mul_geometric`;
- the test for switching to `mbasis` is now `(order <= (ipmat->r))` rather than `if (order <= PMBASIS_THRES)` (to be tuned).

The following tests give an idea of the range of superiority of `nmod_poly_mat_pmbasis_linearized`. A comparison is also made with `nmod_poly_mat_middle_product_geometric` as only modification in `nmod_poly_mat_pmbasis`.

[pmbasis linearized.pdf](https://github.com/user-attachments/files/27304037/pmbasis.linearized.pdf)

Rider: adding a .h that had been forgotten for some of the prototypes in maple.