### PR TITLE
Testing invertibility within truncated inverse + improve middle product prototype 

### DIFF
--- a/flint-extras/src/nmod_poly_mat_dixon.h
+++ b/flint-extras/src/nmod_poly_mat_dixon.h
@@ -23,7 +23,9 @@ extern "C" {
 /**
  *
  *  Truncated inverse of A mod x^order
- *  A is assumed to be invertible for x=0 (will produce an error otherwise) 
+ *  Returns 0 if A is not invertible as a power series (i.e., at x=0),
+ *  in which case S is not modified
+ *  Returns nonzero otherwise, and S is the truncated inverse
  * 
  *  CHECK TODO: uses a method based on a shifted approximant computation 
  *              check whether the specification of nmod_poly_mat_pmbasis 
@@ -31,33 +33,30 @@ extern "C" {
  * 
  */
 
-void nmod_poly_mat_inv_trunc(nmod_poly_mat_t S, 
-                            const nmod_poly_mat_t A, 
-                            ulong order);
+slong nmod_poly_mat_inv_trunc(nmod_poly_mat_t S, 
+                              const nmod_poly_mat_t A, 
+                              ulong order);
 
 
 /**
  * x-adic iterations à la Dixon : AX=B mod x^sigma
  * A is nxn, B is nxm 
- * A is assumed to be invertible for x=0 (will produce an error otherwise) 
+ *  Returns 0 if A is not invertible as a power series (i.e., at x=0),
+ *  in which case X is not modified
+ *  Returns nonzero otherwise, and X is the sought solution
  * 
  * Iterations mod x^order to obtain a total approximation mod x^sigma
  * 
  */
 
-void nmod_poly_mat_dixon(nmod_poly_mat_t X, 
-                            const nmod_poly_mat_t A, 
-                            const nmod_poly_mat_t B, 
-                            ulong order,
-                            ulong sigma);
+slong nmod_poly_mat_dixon(nmod_poly_mat_t X, 
+                          const nmod_poly_mat_t A, 
+                          const nmod_poly_mat_t B, 
+                          ulong order,
+                          ulong sigma);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif
-
-/* -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
-// vim:sts=4:sw=4:ts=4:et:sr:cino=>s,f0,{0,g0,(0,\:0,t0,+0,=s
-
-
+#endif  /* NMOD_POLY_MAT_DIXON_H */

--- a/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
+++ b/flint-extras/src/nmod_poly_mat_extra/approximant_basis.c
@@ -50,7 +50,7 @@ void nmod_poly_mat_pmbasis(nmod_poly_mat_t appbas,
 
     nmod_poly_mat_pmbasis(appbas, shift, pmat, order1);
 
-    nmod_poly_mat_middle_product_naive(residual, appbas, pmat, order1, order2-1);
+    nmod_poly_mat_mulmid_naive(residual, appbas, pmat, order1, order);
 
     nmod_poly_mat_pmbasis(appbas2, shift, residual, order2);
 

--- a/flint-extras/src/nmod_poly_mat_extra/kernel.c
+++ b/flint-extras/src/nmod_poly_mat_extra/kernel.c
@@ -412,7 +412,7 @@ slong nmod_poly_mat_kernel_zls_approx(nmod_poly_mat_t ker,
 
     nmod_poly_mat_init(residual, m - nullity, n, pmat->modulus);
     nmod_poly_mat_window_init(approx, ker, nullity, 0, m, m);
-    nmod_poly_mat_middle_product_naive(residual, approx, pmat, order, order + maxdeg + 1);
+    nmod_poly_mat_mulmid_naive(residual, approx, pmat, order, order + maxdeg + 1);
     /* FIXME provide (and use) general middle_product interface */
     /* note: on non-generic input, one might want to check for zero rows in residual */
 

--- a/flint-extras/src/nmod_poly_mat_extra/middle_product.c
+++ b/flint-extras/src/nmod_poly_mat_extra/middle_product.c
@@ -17,17 +17,15 @@
 #include "nmod_extra.h"
 #include "nmod_poly_mat_multiply.h"
 
-/** Middle product for polynomial matrices
- *  sets C = ((A * B) div x^dA) mod x^(dB+1), assuming deg(A) <= dA and deg(B) <= dA + dB
- *  output can alias input
- *  naive implementation (multiply, shift, truncate)
+/** sets C to the first nhi - nlo middle coefficients of the product of A of
+ *  length len1 and B of length len2 starting at offset nlo
  */
-void nmod_poly_mat_middle_product_naive(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
-                                        const ulong dA, const ulong dB)
+void nmod_poly_mat_mulmid_naive(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
+                                const slong nlo, const slong nhi)
 {
     nmod_poly_mat_mul(C, A, B);
-    nmod_poly_mat_shift_right(C, C, dA);
-    nmod_poly_mat_truncate(C, dB + 1);
+    nmod_poly_mat_truncate(C, nhi);
+    nmod_poly_mat_shift_right(C, C, nlo);
 }
 
 

--- a/flint-extras/src/nmod_poly_mat_extra/nmod_poly_mat_dixon.c
+++ b/flint-extras/src/nmod_poly_mat_extra/nmod_poly_mat_dixon.c
@@ -28,9 +28,9 @@
  *              is as expected
  *
  */
-void nmod_poly_mat_inv_trunc(nmod_poly_mat_t S,
-                            const nmod_poly_mat_t A,
-                            ulong order)
+slong nmod_poly_mat_inv_trunc(nmod_poly_mat_t S,
+                              const nmod_poly_mat_t A,
+                              ulong order)
 {
     const slong n = A->r;
 
@@ -61,21 +61,22 @@ void nmod_poly_mat_inv_trunc(nmod_poly_mat_t S,
     // Shifted approximant computation
     nmod_poly_mat_pmbasis(tsf, shift, H, order);
 
-    // Check whether the lower right part of the approximant is the identity matrix
+    // Check invertibility <=> bottom right block of approximant basis is the identity
     nmod_poly_mat_t view;
     nmod_poly_mat_window_init(view, tsf, n, n, 2*n, 2*n);
-    PML_ASSERT(nmod_poly_mat_is_one(view));
-    /* fails -> error in nmod_poly_mat_inv_trunc: check of identity, singular at origin? */
+    slong is_inv = nmod_poly_mat_is_one(view);
+
+    // Extract the truncated inverse from the approximant basis (bottom left block)
+    if (is_inv)
+        for (slong i = 0; i < n; i++)
+            for (slong j = 0; j < n; j++)
+                nmod_poly_set(nmod_poly_mat_entry(S, i, j), nmod_poly_mat_entry(tsf, n+i, j));
+
     nmod_poly_mat_window_clear(view);
-
-    // Extract the truncated inverse from the approximant basis
-    for (slong i = 0; i < n; i++)
-        for (slong j = 0; j < n; j++)
-            nmod_poly_set(nmod_poly_mat_entry(S, i, j), nmod_poly_mat_entry(tsf, n+i, j));
-
     flint_free(shift);
     nmod_poly_mat_clear(H);
     nmod_poly_mat_clear(tsf);
+    return is_inv;
 }
 
 /**
@@ -89,11 +90,11 @@ void nmod_poly_mat_inv_trunc(nmod_poly_mat_t S,
  * Iterations mod x^order to obtain a total approximation mod x^sigma
  *
  */
-void nmod_poly_mat_dixon(nmod_poly_mat_t X,
-                            const nmod_poly_mat_t A,
-                            const nmod_poly_mat_t B,
-                            ulong order,
-                            ulong sigma)
+slong nmod_poly_mat_dixon(nmod_poly_mat_t X,
+                          const nmod_poly_mat_t A,
+                          const nmod_poly_mat_t B,
+                          ulong order,
+                          ulong sigma)
 {
     const slong m = B->c;
     const slong n = A->r;
@@ -102,7 +103,9 @@ void nmod_poly_mat_dixon(nmod_poly_mat_t X,
     nmod_poly_mat_t C;
     nmod_poly_mat_init(C, n, n, A->modulus);
 
-    nmod_poly_mat_inv_trunc(C, A, order);
+    slong is_inv = nmod_poly_mat_inv_trunc(C, A, order);
+    if (!is_inv)
+        return 0;
 
     // Temporary matrices
     nmod_poly_mat_t S;
@@ -135,4 +138,5 @@ void nmod_poly_mat_dixon(nmod_poly_mat_t X,
     nmod_poly_mat_clear(BB);
     nmod_poly_mat_clear(S);
     nmod_poly_mat_clear(T);
+    return 1;
 }

--- a/flint-extras/src/nmod_poly_mat_extra/profile/p-middle_product.c
+++ b/flint-extras/src/nmod_poly_mat_extra/profile/p-middle_product.c
@@ -33,6 +33,40 @@ typedef struct
 }
 time_args;
 
+#define TIME_MULMID(fun)                                \
+void time_##fun(time_args targs, flint_rand_t state)    \
+{                                                       \
+    const slong rdim = targs.rdim;                      \
+    const slong idim = targs.idim;                      \
+    const slong cdim = targs.cdim;                      \
+    const slong deg = targs.deg;                        \
+    const slong n = targs.modn;                         \
+                                                        \
+    nmod_t mod;                                         \
+    nmod_init(&mod, n);                                 \
+                                                        \
+    nmod_poly_mat_t A;                                  \
+    nmod_poly_mat_init(A, rdim, idim, n);               \
+    nmod_poly_mat_rand(A, state, deg);                  \
+    nmod_poly_mat_t B;                                  \
+    nmod_poly_mat_init(B, idim, cdim, n);               \
+    nmod_poly_mat_rand(B, state, 2*deg-1);              \
+    nmod_poly_mat_t C;                                  \
+    nmod_poly_mat_init(C, rdim, cdim, n);               \
+                                                        \
+    double FLINT_SET_BUT_UNUSED(tcpu), twall;           \
+                                                        \
+    TIMEIT_START;                                       \
+    nmod_poly_mat_##fun(C, A, B, deg-1, 2*deg-1);       \
+    TIMEIT_STOP_VALUES(tcpu, twall);                    \
+                                                        \
+    printf("%.2e", twall);                              \
+                                                        \
+    nmod_poly_mat_clear(A);                             \
+    nmod_poly_mat_clear(B);                             \
+    nmod_poly_mat_clear(C);                             \
+}
+
 #define TIME_TMUL(fun)                                  \
 void time_##fun(time_args targs, flint_rand_t state)    \
 {                                                       \
@@ -67,7 +101,7 @@ void time_##fun(time_args targs, flint_rand_t state)    \
     nmod_poly_mat_clear(C);                             \
 }
 
-TIME_TMUL(middle_product_naive)
+TIME_MULMID(mulmid_naive)
 TIME_TMUL(middle_product_geometric)
 
 /*-------------------------*/
@@ -96,7 +130,7 @@ int main(int argc, char ** argv)
     const slong nfuns = 2;
     typedef void (*timefun) (time_args, flint_rand_t);
     const timefun funs[] = {
-        time_middle_product_naive,                // 0
+        time_mulmid_naive,                        // 0
         time_middle_product_geometric,            // 1
     };
 
@@ -108,7 +142,7 @@ int main(int argc, char ** argv)
     //};
 
     const char * description[] = {
-        "#0  --> middle_product_naive                    ",
+        "#0  --> mulmid_naive                            ",
         "#1  --> middle_product_geometric                ",
     };
 
@@ -132,7 +166,7 @@ int main(int argc, char ** argv)
     for (slong i = 0; i < 3; i++)
     {
         time_args targs = {4, 4, 4, 1000, UWORD(1) << 20};
-        time_middle_product_naive(targs, state);
+        time_mulmid_naive(targs, state);
         printf(" ");
     }
     printf("\n\n");

--- a/flint-extras/src/nmod_poly_mat_extra/test/t-middle_product_geometric.c
+++ b/flint-extras/src/nmod_poly_mat_extra/test/t-middle_product_geometric.c
@@ -35,7 +35,7 @@ int test_mat_middle_product_geometric(ulong bits, ulong m, ulong n, ulong p, ulo
     nmod_poly_mat_rand(C1, state, len);
     nmod_poly_mat_rand(C2, state, len);
 
-    nmod_poly_mat_middle_product_naive(C1, A, B, len-1, len-1);
+    nmod_poly_mat_mulmid_naive(C1, A, B, len-1, 2*len-1);
     nmod_poly_mat_middle_product_geometric(C2, A, B, len-1, len-1);
 
     int res = nmod_poly_mat_equal(C1, C2);

--- a/flint-extras/src/nmod_poly_mat_multiply.h
+++ b/flint-extras/src/nmod_poly_mat_multiply.h
@@ -74,12 +74,15 @@ void nmod_poly_mat_mul_waksman(nmod_poly_mat_t C, const nmod_poly_mat_t A,  cons
 
 
 /** Middle product for polynomial matrices
- *  sets C = ((A * B) div x^dA) mod x^(dB+1), assuming deg(A) <= dA and deg(B) <= dA + dB
+ *  Sets C = ((A * B mod x^nhi) div x^nlo)
+ *  i.e., sets C to the first nhi - nlo middle coefficients of the product of A
+ *  of length len1 and B of length len2 starting at offset nlo
+ *
  *  output can alias input
  *  naive implementation (multiply, shift, truncate)
  */
-void nmod_poly_mat_middle_product_naive(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
-                                        const ulong dA, const ulong dB);
+void nmod_poly_mat_mulmid_naive(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
+                                const slong nlo, const slong nhi);
 
 /** Middle product for polynomial matrices
  *  sets C = ((A * B) div x^dA) mod x^(dB+1)
@@ -114,6 +117,8 @@ void nmod_poly_mat_middle_product_3_primes(nmod_poly_mat_t C, const nmod_poly_ma
  *  uses geometric evaluation and interpolation
  *  \todo currently test fails
  */
+/* TODO check correctness carefully */
+/* TODO unify prototype mulmid */
 void nmod_poly_mat_middle_product_geometric(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
                                             const ulong dA, const ulong dB);
 
@@ -124,6 +129,8 @@ void nmod_poly_mat_middle_product_geometric(nmod_poly_mat_t C, const nmod_poly_m
  *  uses evaluation and interpolation at arithmetic points, done by matrix products
  *  ASSUME: large enough field 
  */
+/* TODO currently disabled */
+/* TODO unify prototype mulmid */
 void nmod_poly_mat_middle_product_vdm1(nmod_poly_mat_t C, const nmod_poly_mat_t A, const nmod_poly_mat_t B,
                                        const ulong dA, const ulong dB);
 


### PR DESCRIPTION
This modifies linear system solving and truncated inverse functions _à la Dixon_ so that invertibility does not throw an error (or fail silently), but an integer is returned to indicate the non-invertibility / invertibility. 

Some comments. In FLINT, for example in `nmod_poly_inv_series`, the function does not accept non-invertible input. We could choose to do the same, but one caveat is that here, for polynomial matrices, checking invertibility has some cost that we may want to avoid (typically, extracting constant matrix and checking it is invertible). On the other hand, the methods going through pmbasis or Newton inversion will tell us, with no additional cost, if invertibility holds, so it seems better to detect it on the fly and return an integer to report on invertibility.

Another part of this PR is to make the functions for middle product closer to the existing `mulmid` functions in FLINT.