### PR TITLE
Update CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -248,7 +248,7 @@ jobs:
         run: |
           cd flint-extras
           ./bootstrap.sh
-          ./configure CC=$(CC) --enable-asan --disable-debug
+          ./configure CC=${CC} --enable-asan --disable-debug
       - name: "Compile library"
         run: cd flint-extras && $MAKE && ldd libpml.so
       - name: "Compile tests"
@@ -353,7 +353,7 @@ jobs:
           cd flint
           ./bootstrap.sh
           ./configure \
-            CC=$(CC) \
+            CC=${CC} \
             --with-gmp=$(brew --prefix) \
             --with-mpfr=$(brew --prefix) \
             --disable-debug
@@ -365,7 +365,7 @@ jobs:
           cd flint-extras
           ./bootstrap.sh
           ./configure \
-            CC=$(CC) \
+            CC=${CC} \
             --with-gmp=$(brew --prefix) \
             --with-mpfr=$(brew --prefix) \
             --disable-debug


### PR DESCRIPTION
Typos maybe.  (CC) command substitution (tries to run a command literally named CC), not {CC} variable expansion of the job's CC: "clang" env var. Changed to ${CC} . 